### PR TITLE
Add a separate COPYING file

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -27,3 +27,9 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+Everything in this source tree is covered by the previous license
+with the following exceptions:
+
+* utils/cstyle (used only during development) licensed under CDDL.


### PR DESCRIPTION
Based on comment by @krzycz 
"For convenience, I'd consider keeping the 3-clause BSD license text in a separate file and changing this one to COPYING.md.
The main license text could be included here with additional notes."

This way, github also automatically recognizes the project as being under BSD 3-clause license.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marcinslusarz/pmemfile/94)
<!-- Reviewable:end -->
