### PR TITLE
posix: pread & pwrite

### DIFF
--- a/src/libpmemfile-posix/data.c
+++ b/src/libpmemfile-posix/data.c
@@ -582,7 +582,7 @@ vinode_write(PMEMfilepool *pfp, struct pmemfile_vinode *vinode, size_t offset,
 }
 
 static pmemfile_ssize_t
-pmemfile_write_locked(PMEMfilepool *pfp,
+pmemfile_pwrite_internal(PMEMfilepool *pfp,
 		struct pmemfile_vinode *vinode,
 		struct pmemfile_block **last_block,
 		uint64_t file_flags,
@@ -671,8 +671,8 @@ pmemfile_write(PMEMfilepool *pfp, PMEMfile *file, const void *buf, size_t count)
 	os_mutex_lock(&file->mutex);
 
 	struct pmemfile_block *last_block = file->block_pointer_cache;
-	ret = pmemfile_write_locked(pfp, file->vinode, &last_block, file->flags,
-			file->offset, buf, count);
+	ret = pmemfile_pwrite_internal(pfp, file->vinode, &last_block,
+			file->flags, file->offset, buf, count);
 	if (ret >= 0) {
 		file->offset += (size_t)ret;
 		file->block_pointer_cache = last_block;
@@ -731,7 +731,7 @@ time_cmp(const struct pmemfile_time *t1, const struct pmemfile_time *t2)
 }
 
 static pmemfile_ssize_t
-pmemfile_read_locked(PMEMfilepool *pfp,
+pmemfile_pread_internal(PMEMfilepool *pfp,
 		struct pmemfile_vinode *vinode,
 		struct pmemfile_block **last_block,
 		uint64_t file_flags,
@@ -827,8 +827,8 @@ pmemfile_read(PMEMfilepool *pfp, PMEMfile *file, void *buf, size_t count)
 	os_mutex_lock(&file->mutex);
 
 	struct pmemfile_block *last_block = file->block_pointer_cache;
-	ret = pmemfile_read_locked(pfp, file->vinode, &last_block, file->flags,
-			file->offset, buf, count);
+	ret = pmemfile_pread_internal(pfp, file->vinode, &last_block,
+			file->flags, file->offset, buf, count);
 	if (ret >= 0) {
 		file->offset += (size_t)ret;
 		file->block_pointer_cache = last_block;
@@ -1093,17 +1093,16 @@ pmemfile_pread(PMEMfilepool *pfp, PMEMfile *file, void *buf, size_t count,
 		return -1;
 	}
 
-	pmemfile_ssize_t ret;
-
 	os_mutex_lock(&file->mutex);
 
 	struct pmemfile_block *last_block = file->block_pointer_cache;
-	ret = pmemfile_read_locked(pfp, file->vinode, &last_block, file->flags,
-			(size_t)offset, buf, count);
+	struct pmemfile_vinode *vinode = file->vinode;
+	uint64_t flags = file->flags;
 
 	os_mutex_unlock(&file->mutex);
 
-	return ret;
+	return pmemfile_pread_internal(pfp, vinode, &last_block, flags,
+			(size_t)offset, buf, count);
 }
 
 pmemfile_ssize_t
@@ -1127,17 +1126,16 @@ pmemfile_pwrite(PMEMfilepool *pfp, PMEMfile *file, const void *buf,
 		return -1;
 	}
 
-	pmemfile_ssize_t ret;
-
 	os_mutex_lock(&file->mutex);
 
 	struct pmemfile_block *last_block = file->block_pointer_cache;
-	ret = pmemfile_write_locked(pfp, file->vinode, &last_block, file->flags,
-			(size_t)offset, buf, count);
+	struct pmemfile_vinode *vinode = file->vinode;
+	uint64_t flags = file->flags;
 
 	os_mutex_unlock(&file->mutex);
 
-	return ret;
+	return pmemfile_pwrite_internal(pfp, vinode, &last_block, flags,
+			(size_t)offset, buf, count);
 }
 
 /*

--- a/src/libpmemfile-posix/data.c
+++ b/src/libpmemfile-posix/data.c
@@ -360,13 +360,13 @@ vinode_allocate_interval(PMEMfilepool *pfp, struct pmemfile_vinode *vinode,
 }
 
 static struct pmemfile_block *
-find_following_block(PMEMfile * file,
+find_following_block(struct pmemfile_vinode *vinode,
 	struct pmemfile_block *block)
 {
 	if (block != NULL)
 		return D_RW(block->next);
 	else
-		return file->vinode->first_block;
+		return vinode->first_block;
 }
 
 enum cpy_direction { read_from_blocks, write_to_blocks };
@@ -459,7 +459,7 @@ iterate_on_file_range(PMEMfilepool *pfp, PMEMfile *file,
 			ASSERT(dir == read_from_blocks);
 
 			struct pmemfile_block *next_block =
-			    find_following_block(file, block);
+			    find_following_block(file->vinode, block);
 
 			/*
 			 * How many zero bytes should be read?

--- a/src/libpmemfile-posix/data.c
+++ b/src/libpmemfile-posix/data.c
@@ -650,6 +650,18 @@ pmemfile_write(PMEMfilepool *pfp, PMEMfile *file, const void *buf, size_t count)
 {
 	pmemfile_ssize_t ret;
 
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
+	if (!file) {
+		LOG(LUSR, "NULL file");
+		errno = EFAULT;
+		return -1;
+	}
+
 	os_mutex_lock(&file->mutex);
 	ret = pmemfile_write_locked(pfp, file, buf, count);
 	os_mutex_unlock(&file->mutex);
@@ -776,6 +788,18 @@ pmemfile_ssize_t
 pmemfile_read(PMEMfilepool *pfp, PMEMfile *file, void *buf, size_t count)
 {
 	pmemfile_ssize_t ret;
+
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
+	if (!file) {
+		LOG(LUSR, "NULL file");
+		errno = EFAULT;
+		return -1;
+	}
 
 	os_mutex_lock(&file->mutex);
 	ret = pmemfile_read_locked(pfp, file, buf, count);
@@ -995,6 +1019,18 @@ pmemfile_off_t
 pmemfile_lseek(PMEMfilepool *pfp, PMEMfile *file, pmemfile_off_t offset,
 		int whence)
 {
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
+	if (!file) {
+		LOG(LUSR, "NULL file");
+		errno = EFAULT;
+		return -1;
+	}
+
 	COMPILE_ERROR_ON(sizeof(offset) != 8);
 	pmemfile_off_t ret;
 
@@ -1010,6 +1046,18 @@ pmemfile_pread(PMEMfilepool *pfp, PMEMfile *file, void *buf, size_t count,
 		pmemfile_off_t offset)
 {
 	/* XXX this is hacky implementation */
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
+	if (!file) {
+		LOG(LUSR, "NULL file");
+		errno = EFAULT;
+		return -1;
+	}
+
 	pmemfile_ssize_t ret;
 	os_mutex_lock(&file->mutex);
 
@@ -1036,6 +1084,18 @@ pmemfile_pwrite(PMEMfilepool *pfp, PMEMfile *file, const void *buf,
 		size_t count, pmemfile_off_t offset)
 {
 	/* XXX this is hacky implementation */
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
+	if (!file) {
+		LOG(LUSR, "NULL file");
+		errno = EFAULT;
+		return -1;
+	}
+
 	pmemfile_ssize_t ret;
 	os_mutex_lock(&file->mutex);
 

--- a/src/libpmemfile-posix/data.c
+++ b/src/libpmemfile-posix/data.c
@@ -138,6 +138,16 @@ is_block_data_initialized(const struct pmemfile_block *block)
 }
 
 /*
+ * find_block -- look up block metadata with the highest offset
+ * lower than or equal to the offset argument
+ */
+static struct pmemfile_block *
+find_block(struct pmemfile_vinode *vinode, uint64_t off)
+{
+	return (void *)(uintptr_t)ctree_find_le_unlocked(vinode->blocks, &off);
+}
+
+/*
  * file_find_block -- look up block metadata with the highest offset
  * lower than or equal to the offset argument
  *
@@ -150,22 +160,7 @@ file_find_block(struct pmemfile_file *file, struct pmemfile_block *last_block,
 	if (is_offset_in_block(last_block, offset))
 		return last_block;
 
-	struct pmemfile_block *block;
-
-	block = (void *)(uintptr_t)ctree_find_le_unlocked(file->vinode->blocks,
-	    &offset);
-
-	return block;
-}
-
-/*
- * find_block -- look up block metadata with the highest offset
- * lower than or equal to the offset argument
- */
-static struct pmemfile_block *
-find_block(struct pmemfile_vinode *vinode, uint64_t off)
-{
-	return (void *)(uintptr_t)ctree_find_le_unlocked(vinode->blocks, &off);
+	return find_block(file->vinode, offset);
 }
 
 /*

--- a/src/libpmemfile-posix/data.c
+++ b/src/libpmemfile-posix/data.c
@@ -154,9 +154,6 @@ file_find_block(struct pmemfile_file *file, uint64_t offset)
 	block = (void *)(uintptr_t)ctree_find_le_unlocked(file->vinode->blocks,
 	    &offset);
 
-	if (block != NULL)
-		file->block_pointer_cache = block;
-
 	return block;
 }
 

--- a/src/libpmemfile-posix/dir.c
+++ b/src/libpmemfile-posix/dir.c
@@ -693,7 +693,17 @@ int
 pmemfile_getdents(PMEMfilepool *pfp, PMEMfile *file,
 			struct linux_dirent *dirp, unsigned count)
 {
-	(void) pfp;
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
+	if (!file) {
+		LOG(LUSR, "NULL file");
+		errno = EFAULT;
+		return -1;
+	}
 
 	struct pmemfile_vinode *vinode = file->vinode;
 
@@ -811,7 +821,17 @@ int
 pmemfile_getdents64(PMEMfilepool *pfp, PMEMfile *file,
 			struct linux_dirent64 *dirp, unsigned count)
 {
-	(void) pfp;
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
+	if (!file) {
+		LOG(LUSR, "NULL file");
+		errno = EFAULT;
+		return -1;
+	}
 
 	struct pmemfile_vinode *vinode = file->vinode;
 
@@ -1127,8 +1147,20 @@ pmemfile_mkdirat(PMEMfilepool *pfp, PMEMfile *dir, const char *path,
 	struct pmemfile_vinode *at;
 	bool at_unref;
 
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
 	if (!path) {
 		errno = ENOENT;
+		return -1;
+	}
+
+	if (path[0] != '/' && !dir) {
+		LOG(LUSR, "NULL dir");
+		errno = EFAULT;
 		return -1;
 	}
 
@@ -1322,6 +1354,12 @@ pmemfile_rmdir(PMEMfilepool *pfp, const char *path)
 	struct pmemfile_vinode *at;
 	bool at_unref;
 
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
 	if (!path) {
 		errno = ENOENT;
 		return -1;
@@ -1374,6 +1412,12 @@ pmemfile_chdir(PMEMfilepool *pfp, const char *path)
 	int error = 0;
 	bool at_unref;
 
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
 	if (!path) {
 		errno = ENOENT;
 		return -1;
@@ -1410,6 +1454,18 @@ end:
 int
 pmemfile_fchdir(PMEMfilepool *pfp, PMEMfile *dir)
 {
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
+	if (!dir) {
+		LOG(LUSR, "NULL dir");
+		errno = EFAULT;
+		return -1;
+	}
+
 	int ret;
 	struct pmemfile_cred cred;
 	if (get_cred(pfp, &cred))
@@ -1552,6 +1608,18 @@ range_err:
 char *
 pmemfile_get_dir_path(PMEMfilepool *pfp, PMEMfile *dir, char *buf, size_t size)
 {
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return NULL;
+	}
+
+	if (!dir) {
+		LOG(LUSR, "NULL dir");
+		errno = EFAULT;
+		return NULL;
+	}
+
 	struct pmemfile_vinode *vdir;
 
 	if (dir == PMEMFILE_AT_CWD)
@@ -1565,5 +1633,11 @@ pmemfile_get_dir_path(PMEMfilepool *pfp, PMEMfile *dir, char *buf, size_t size)
 char *
 pmemfile_getcwd(PMEMfilepool *pfp, char *buf, size_t size)
 {
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return NULL;
+	}
+
 	return _pmemfile_get_dir_path(pfp, pool_get_cwd(pfp), buf, size);
 }

--- a/src/libpmemfile-posix/file.c
+++ b/src/libpmemfile-posix/file.c
@@ -448,9 +448,21 @@ PMEMfile *
 pmemfile_openat(PMEMfilepool *pfp, PMEMfile *dir, const char *pathname,
 		int flags, ...)
 {
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return NULL;
+	}
+
 	if (!pathname) {
 		LOG(LUSR, "NULL pathname");
 		errno = ENOENT;
+		return NULL;
+	}
+
+	if (pathname[0] != '/' && !dir) {
+		LOG(LUSR, "NULL dir");
+		errno = EFAULT;
 		return NULL;
 	}
 
@@ -507,6 +519,24 @@ PMEMfile *
 pmemfile_open_parent(PMEMfilepool *pfp, PMEMfile *dir, char *path,
 		size_t path_size, int flags)
 {
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return NULL;
+	}
+
+	if (!path) {
+		LOG(LUSR, "NULL path");
+		errno = ENOENT;
+		return NULL;
+	}
+
+	if (path[0] != '/' && !dir) {
+		LOG(LUSR, "NULL dir");
+		errno = EFAULT;
+		return NULL;
+	}
+
 	PMEMfile *ret = NULL;
 	struct pmemfile_vinode *at;
 	bool at_unref;
@@ -716,12 +746,30 @@ int
 pmemfile_linkat(PMEMfilepool *pfp, PMEMfile *olddir, const char *oldpath,
 		PMEMfile *newdir, const char *newpath, int flags)
 {
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
 	struct pmemfile_vinode *olddir_at, *newdir_at;
 	bool olddir_at_unref, newdir_at_unref;
 
 	if (!oldpath || !newpath) {
 		LOG(LUSR, "NULL pathname");
 		errno = ENOENT;
+		return -1;
+	}
+
+	if (oldpath[0] != '/' && !olddir) {
+		LOG(LUSR, "NULL old dir");
+		errno = EFAULT;
+		return -1;
+	}
+
+	if (newpath[0] != '/' && !newdir) {
+		LOG(LUSR, "NULL new dir");
+		errno = EFAULT;
 		return -1;
 	}
 
@@ -754,6 +802,12 @@ pmemfile_linkat(PMEMfilepool *pfp, PMEMfile *olddir, const char *oldpath,
 int
 pmemfile_link(PMEMfilepool *pfp, const char *oldpath, const char *newpath)
 {
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
 	struct pmemfile_vinode *at;
 
 	if (!oldpath || !newpath) {
@@ -840,11 +894,23 @@ int
 pmemfile_unlinkat(PMEMfilepool *pfp, PMEMfile *dir, const char *pathname,
 		int flags)
 {
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
 	struct pmemfile_vinode *at;
 	bool at_unref;
 
 	if (!pathname) {
 		errno = ENOENT;
+		return -1;
+	}
+
+	if (pathname[0] != '/' && !dir) {
+		LOG(LUSR, "NULL dir");
+		errno = EFAULT;
 		return -1;
 	}
 
@@ -1032,6 +1098,12 @@ end:
 int
 pmemfile_rename(PMEMfilepool *pfp, const char *old_path, const char *new_path)
 {
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
 	struct pmemfile_vinode *at;
 
 	if (!old_path || !new_path) {
@@ -1057,12 +1129,30 @@ int
 pmemfile_renameat2(PMEMfilepool *pfp, PMEMfile *old_at, const char *old_path,
 		PMEMfile *new_at, const char *new_path, unsigned flags)
 {
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
 	struct pmemfile_vinode *olddir_at, *newdir_at;
 	bool olddir_at_unref, newdir_at_unref;
 
 	if (!old_path || !new_path) {
 		LOG(LUSR, "NULL pathname");
 		errno = ENOENT;
+		return -1;
+	}
+
+	if (old_path[0] != '/' && !old_at) {
+		LOG(LUSR, "NULL old dir");
+		errno = EFAULT;
+		return -1;
+	}
+
+	if (new_path[0] != '/' && !new_at) {
+		LOG(LUSR, "NULL new dir");
+		errno = EFAULT;
 		return -1;
 	}
 
@@ -1180,8 +1270,20 @@ pmemfile_symlinkat(PMEMfilepool *pfp, const char *target, PMEMfile *newdir,
 	struct pmemfile_vinode *at;
 	bool at_unref;
 
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
 	if (!target || !linkpath) {
 		errno = ENOENT;
+		return -1;
+	}
+
+	if (linkpath[0] != '/' && !newdir) {
+		LOG(LUSR, "NULL dir");
+		errno = EFAULT;
 		return -1;
 	}
 
@@ -1272,8 +1374,20 @@ pmemfile_readlinkat(PMEMfilepool *pfp, PMEMfile *dir, const char *pathname,
 	struct pmemfile_vinode *at;
 	bool at_unref;
 
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
 	if (!pathname) {
 		errno = ENOENT;
+		return -1;
+	}
+
+	if (pathname[0] != '/' && !dir) {
+		LOG(LUSR, "NULL dir");
+		errno = EFAULT;
 		return -1;
 	}
 
@@ -1298,10 +1412,19 @@ pmemfile_readlink(PMEMfilepool *pfp, const char *pathname, char *buf,
 int
 pmemfile_fcntl(PMEMfilepool *pfp, PMEMfile *file, int cmd, ...)
 {
-	int ret = 0;
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
 
-	(void) pfp;
-	(void) file;
+	if (!file) {
+		LOG(LUSR, "NULL file");
+		errno = EFAULT;
+		return -1;
+	}
+
+	int ret = 0;
 
 	switch (cmd) {
 		case PMEMFILE_F_SETLK:
@@ -1471,8 +1594,20 @@ pmemfile_fchmodat(PMEMfilepool *pfp, PMEMfile *dir, const char *pathname,
 	struct pmemfile_vinode *at;
 	bool at_unref;
 
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
 	if (!pathname) {
 		errno = ENOENT;
+		return -1;
+	}
+
+	if (pathname[0] != '/' && !dir) {
+		LOG(LUSR, "NULL dir");
+		errno = EFAULT;
 		return -1;
 	}
 
@@ -1495,8 +1630,15 @@ pmemfile_chmod(PMEMfilepool *pfp, const char *path, pmemfile_mode_t mode)
 int
 pmemfile_fchmod(PMEMfilepool *pfp, PMEMfile *file, pmemfile_mode_t mode)
 {
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
 	if (!file) {
-		errno = EBADF;
+		LOG(LUSR, "NULL file");
+		errno = EFAULT;
 		return -1;
 	}
 
@@ -1521,6 +1663,12 @@ pmemfile_fchmod(PMEMfilepool *pfp, PMEMfile *file, pmemfile_mode_t mode)
 int
 pmemfile_setreuid(PMEMfilepool *pfp, pmemfile_uid_t ruid, pmemfile_uid_t euid)
 {
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
 	if (ruid != (pmemfile_uid_t)-1 && ruid > INT_MAX) {
 		errno = EINVAL;
 		return -1;
@@ -1549,6 +1697,12 @@ pmemfile_setreuid(PMEMfilepool *pfp, pmemfile_uid_t ruid, pmemfile_uid_t euid)
 int
 pmemfile_setregid(PMEMfilepool *pfp, pmemfile_gid_t rgid, pmemfile_gid_t egid)
 {
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
 	if (rgid != (pmemfile_gid_t)-1 && rgid > INT_MAX) {
 		errno = EINVAL;
 		return -1;
@@ -1665,6 +1819,12 @@ pmemfile_getegid(PMEMfilepool *pfp)
 int
 pmemfile_setfsuid(PMEMfilepool *pfp, pmemfile_uid_t fsuid)
 {
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
 	if (fsuid > INT_MAX) {
 		errno = EINVAL;
 		return -1;
@@ -1684,6 +1844,12 @@ pmemfile_setfsuid(PMEMfilepool *pfp, pmemfile_uid_t fsuid)
 int
 pmemfile_setfsgid(PMEMfilepool *pfp, pmemfile_gid_t fsgid)
 {
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
 	if (fsgid > INT_MAX) {
 		errno = EINVAL;
 		return -1;
@@ -1703,6 +1869,12 @@ pmemfile_setfsgid(PMEMfilepool *pfp, pmemfile_gid_t fsgid)
 int
 pmemfile_getgroups(PMEMfilepool *pfp, int size, pmemfile_gid_t list[])
 {
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
 	if (size < 0) {
 		errno = EINVAL;
 		return -1;
@@ -1729,6 +1901,12 @@ pmemfile_getgroups(PMEMfilepool *pfp, int size, pmemfile_gid_t list[])
 int
 pmemfile_setgroups(PMEMfilepool *pfp, size_t size, const pmemfile_gid_t *list)
 {
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
 	int error = 0;
 	os_rwlock_wrlock(&pfp->cred_rwlock);
 	if (size != pfp->cred.groupsnum) {
@@ -1782,6 +1960,18 @@ _pmemfile_ftruncate(PMEMfilepool *pfp, struct pmemfile_vinode *vinode,
 int
 pmemfile_ftruncate(PMEMfilepool *pfp, PMEMfile *file, pmemfile_off_t length)
 {
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
+	if (!file) {
+		LOG(LUSR, "NULL file");
+		errno = EFAULT;
+		return -1;
+	}
+
 	int ret;
 
 	if (length < 0) {
@@ -1819,6 +2009,18 @@ pmemfile_ftruncate(PMEMfilepool *pfp, PMEMfile *file, pmemfile_off_t length)
 int
 pmemfile_truncate(PMEMfilepool *pfp, const char *path, pmemfile_off_t length)
 {
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
+	if (!path) {
+		LOG(LUSR, "NULL path");
+		errno = EFAULT;
+		return -1;
+	}
+
 	if (length < 0) {
 		errno = EINVAL;
 		return -1;
@@ -1997,6 +2199,18 @@ int
 pmemfile_fallocate(PMEMfilepool *pfp, PMEMfile *file, int mode,
 		pmemfile_off_t offset, pmemfile_off_t length)
 {
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
+	if (!file) {
+		LOG(LUSR, "NULL file");
+		errno = EFAULT;
+		return -1;
+	}
+
 	int error;
 
 	error = fallocate_check_arguments(mode, offset, length);
@@ -2150,8 +2364,20 @@ pmemfile_fchownat(PMEMfilepool *pfp, PMEMfile *dir, const char *pathname,
 	struct pmemfile_vinode *at;
 	bool at_unref;
 
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
 	if (!pathname) {
 		errno = ENOENT;
+		return -1;
+	}
+
+	if (pathname[0] != '/' && !dir) {
+		LOG(LUSR, "NULL dir");
+		errno = EFAULT;
 		return -1;
 	}
 
@@ -2185,8 +2411,15 @@ int
 pmemfile_fchown(PMEMfilepool *pfp, PMEMfile *file, pmemfile_uid_t owner,
 		pmemfile_gid_t group)
 {
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
 	if (!file) {
-		errno = EBADF;
+		LOG(LUSR, "NULL file");
+		errno = EFAULT;
 		return -1;
 	}
 
@@ -2287,8 +2520,20 @@ pmemfile_faccessat(PMEMfilepool *pfp, PMEMfile *dir, const char *pathname,
 	struct pmemfile_vinode *at;
 	bool at_unref;
 
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
 	if (!pathname) {
 		errno = ENOENT;
+		return -1;
+	}
+
+	if (pathname[0] != '/' && !dir) {
+		LOG(LUSR, "NULL dir");
+		errno = EFAULT;
 		return -1;
 	}
 

--- a/src/libpmemfile-posix/inode.c
+++ b/src/libpmemfile-posix/inode.c
@@ -762,8 +762,20 @@ pmemfile_fstatat(PMEMfilepool *pfp, PMEMfile *dir, const char *path,
 	struct pmemfile_vinode *at;
 	bool at_unref;
 
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
 	if (!path) {
 		errno = ENOENT;
+		return -1;
+	}
+
+	if (path[0] != '/' && !dir) {
+		LOG(LUSR, "NULL file");
+		errno = EFAULT;
 		return -1;
 	}
 
@@ -792,8 +804,14 @@ pmemfile_stat(PMEMfilepool *pfp, const char *path, pmemfile_stat_t *buf)
 int
 pmemfile_fstat(PMEMfilepool *pfp, PMEMfile *file, pmemfile_stat_t *buf)
 {
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
 	if (!file) {
-		errno = EBADF;
+		errno = EFAULT;
 		return -1;
 	}
 

--- a/src/libpmemfile-posix/pool.c
+++ b/src/libpmemfile-posix/pool.c
@@ -468,6 +468,12 @@ put_cred(struct pmemfile_cred *cred)
 int
 pmemfile_setcap(PMEMfilepool *pfp, int cap)
 {
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
 	int ret = 0;
 	os_rwlock_wrlock(&pfp->cred_rwlock);
 	switch (cap) {
@@ -490,6 +496,12 @@ pmemfile_setcap(PMEMfilepool *pfp, int cap)
 int
 pmemfile_clrcap(PMEMfilepool *pfp, int cap)
 {
+	if (!pfp) {
+		LOG(LUSR, "NULL pool");
+		errno = EFAULT;
+		return -1;
+	}
+
 	int ret = 0;
 	os_rwlock_wrlock(&pfp->cred_rwlock);
 	switch (cap) {


### PR DESCRIPTION
One of the goals of this patchset is decoupling of file handle updates from actual read & write.
Thanks to that it's now possible to pread from one file handle from multiple threads.

Builds on top of PR #101.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/102)
<!-- Reviewable:end -->
