### PR TITLE
Include the FindThreads cmake module

### DIFF
--- a/tests/posix/CMakeLists.txt
+++ b/tests/posix/CMakeLists.txt
@@ -33,6 +33,7 @@ add_c_flag(-fno-strict-aliasing)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+include(FindThreads)
 include(ExternalProject)
 set(GTEST_VERSION 1.8.0)
 


### PR DESCRIPTION
The CMAKE_THREAD_LIBS_INIT cmake variable is set by the FindThreads
cmake module.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/107)
<!-- Reviewable:end -->
