### PR TITLE
preload: add PMEMFILE_CD env var

### DIFF
--- a/src/libpmemfile/preload.c
+++ b/src/libpmemfile/preload.c
@@ -230,6 +230,12 @@ pmemfile_preload_constructor(void)
 	 * after the call to init_hooking()
 	 */
 	init_hooking();
+
+	char *cd = getenv("PMEMFILE_CD");
+	if (cd && chdir(cd)) {
+		perror("chdir");
+		exit(1);
+	}
 }
 
 static void

--- a/tests/preload/basic_commands/basic_commands.cmake
+++ b/tests/preload/basic_commands/basic_commands.cmake
@@ -84,6 +84,11 @@ list_files(ls_with_dir.log ${DIR}/mount_point)
 rmdir(${DIR}/mount_point/dummy_dir_a)
 list_files(ls_without_dir.log ${DIR}/mount_point)
 
+set(ENV{PMEMFILE_CD} ${DIR}/mount_point)
+mkdir(dir_inside)
+unset(ENV{PMEMFILE_CD})
+execute(stat ${DIR}/mount_point/dir_inside)
+
 # todo: when rm works...
 #  only faccessat seems to be missing for rm to work
 # expect_normal_exit rm ${DIR}/dummy_mount_point/file_a


### PR DESCRIPTION
It allows user change working directory for child process,
without changing it in the parent (which is not possible because
of missing multi-process support).

So instead of:
cd /mnt/pmemfile-mountpoint
ls -l $PATH_RELATIVE_TO_MOUNTPOINT

PMEMFILE_CD=/mnt/pmemfile-mountpoint ls -l $PATH_RELATIVE_TO_MOUNTPOINT

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/113)
<!-- Reviewable:end -->
