### PR TITLE
tests: speedup rw test

### DIFF
--- a/tests/posix/rw/rw.cmake
+++ b/tests/posix/rw/rw.cmake
@@ -36,7 +36,7 @@ setup()
 if(LONG_TESTS OR NOT (TRACER STREQUAL "pmemcheck"))
 	execute(${TEST_EXECUTABLE})
 else()
-	execute(${TEST_EXECUTABLE} --gtest_filter=-rw.2)
+	execute(${TEST_EXECUTABLE} --gtest_filter=-rw.huge_file)
 endif()
 
 cleanup()


### PR DESCRIPTION
In commit 6af84afbedafd934dc1a4e1e1bcb7ba76885f4de I renamed two of
the tests, but forgot to change the execution script which excludes
one of them in non-long configurations...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/117)
<!-- Reviewable:end -->
