### PR TITLE
cmake: use only clang-format 3.8 or 3.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,9 +331,9 @@ add_custom_target(tests)
 
 option(DEVELOPER_MODE "enable developer checks" OFF)
 if(DEVELOPER_MODE)
-	find_program(CLANG_FORMAT NAMES clang-format-3.9 clang-format-3.8 clang-format)
+	find_program(CLANG_FORMAT NAMES clang-format-3.9 clang-format-3.8)
 	if (NOT CLANG_FORMAT)
-		message(WARNING "clang-format not found - C++ sources will not be checked")
+		message(WARNING "clang-format not found - C++ sources will not be checked (needed version: 3.8 or 3.9)")
 	endif()
 
 	execute_process(COMMAND ${PERL_EXECUTABLE} -MText::Diff -e ""


### PR DESCRIPTION
Different versions seem to format code in a bit different way.
This can easily break builds when DEVELOPER_MODE is set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/125)
<!-- Reviewable:end -->
#124 