### PR TITLE
tests: fix TESTS_USE_FORCED_PMEM=ON

### DIFF
--- a/tests/posix/posix-helpers.cmake
+++ b/tests/posix/posix-helpers.cmake
@@ -40,12 +40,12 @@ function(cleanup)
 endfunction()
 
 function(execute name)
-	if(${TESTS_USE_FORCED_PMEM})
+	if(TESTS_USE_FORCED_PMEM)
 		set(ENV{PMEM_IS_PMEM_FORCE} 1)
 	endif()
 
 	if(${TRACER} STREQUAL pmemcheck)
-		if(${TESTS_USE_FORCED_PMEM})
+		if(TESTS_USE_FORCED_PMEM)
 			# pmemcheck runs really slow with pmem, disable it
 			set(ENV{PMEM_IS_PMEM_FORCE} 0)
 		endif()
@@ -71,7 +71,7 @@ function(execute name)
 			RESULT_VARIABLE HAD_ERROR
 			OUTPUT_FILE ${BIN_DIR}/${TRACER}.out
 			ERROR_FILE ${BIN_DIR}/${TRACER}.err)
-	if(${TESTS_USE_FORCED_PMEM})
+	if(TESTS_USE_FORCED_PMEM)
 		unset(ENV{PMEM_IS_PMEM_FORCE})
 	endif()
 

--- a/tests/preload/preload-helpers.cmake
+++ b/tests/preload/preload-helpers.cmake
@@ -34,7 +34,7 @@ include(${SRC_DIR}/../../helpers.cmake)
 function(setup)
 	common_setup()
 
-	if(${TESTS_USE_FORCED_PMEM})
+	if(TESTS_USE_FORCED_PMEM)
 		set(ENV{PMEM_IS_PMEM_FORCE} 1)
 	endif()
 endfunction()
@@ -42,7 +42,7 @@ endfunction()
 function(cleanup)
 	unset(ENV{LD_PRELOAD})
 
-	if(${TESTS_USE_FORCED_PMEM})
+	if(TESTS_USE_FORCED_PMEM)
 		unset(ENV{PMEM_IS_PMEM_FORCE})
 	endif()
 


### PR DESCRIPTION
"if (${VAR})" evaluates to "if (ON)" when VAR=ON. So now cmake evaluates
"if (ON)" which is not true, because it tries to evaluate variable
"ON" which is not set.

"if (VAR)" works both when VAR=1 or VAR=ON.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/141)
<!-- Reviewable:end -->
