### PR TITLE
cmake: Refactor gtest related sections

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -32,5 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 Everything in this source tree is covered by the previous license
 with the following exceptions:
 
-* utils/cstyle (used only during development) licensed under CDDL.
-* cmake/cmake_uninstall.cmake.in licensed under Creative Commons.
+* utils/cstyle (used only during development) is licensed under CDDL.
+* cmake/cmake_uninstall.cmake.in is licensed under Creative Commons.
+* tests/posix/gtest.cmake (used only during development) is licensed
+  under Apache License 2.0

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Pmemfile-specific cmake variables:
 * TRACE_TESTS=1 - dumps more info when test fails (requires cmake >= 3.4)
 * TESTS_USE_FORCED_PMEM=1 - allows tests to force enable or force disable use of optimized flush in libpmemobj (to speed them up)
 * SANITIZERS=1 - enables AddressSanitizer and UndefinedBehaviorSanitizer (only for debugging)
+* USE_SYSTEM_GTEST enables the use system installed gtest (gtest is downloaded from github by default)
 
 # Package for Debian-based distros
 ```sh

--- a/tests/posix/CMakeLists.txt
+++ b/tests/posix/CMakeLists.txt
@@ -35,30 +35,13 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 include(FindThreads)
 include(ExternalProject)
-set(GTEST_VERSION 1.8.0)
 
-if(EXISTS ${CMAKE_SOURCE_DIR}/googletest-${GTEST_VERSION}.zip)
-	set(GTEST_URL ${CMAKE_SOURCE_DIR}/googletest-${GTEST_VERSION}.zip)
-else()
-	set(GTEST_URL https://github.com/google/googletest/archive/release-${GTEST_VERSION}.zip)
+include(gtest.cmake)
+if(NOT GTEST_FOUND)
+	message(FATAL "unable to locate gtest, tests can not be built")
 endif()
-ExternalProject_Add(
-	gtest
-	URL ${GTEST_URL}
-	DOWNLOAD_NAME googletest-${GTEST_VERSION}.zip
-	DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}
-	PREFIX ${CMAKE_CURRENT_BINARY_DIR}/gtest
-	INSTALL_COMMAND ""
-	CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-)
-ExternalProject_Get_Property(gtest source_dir binary_dir)
-add_library(libgtest IMPORTED STATIC GLOBAL)
-add_dependencies(libgtest gtest)
-set_target_properties(libgtest PROPERTIES
-	"IMPORTED_LOCATION" "${binary_dir}/googlemock/gtest/libgtest.a"
-	"IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
-)
-include_directories("${source_dir}/googletest/include")
+
+include_directories(${GTEST_INCLUDE_DIRS})
 
 include_directories(.)
 if(LIBUNWIND_FOUND)
@@ -66,9 +49,8 @@ if(LIBUNWIND_FOUND)
 endif()
 
 add_library(pmemfile_test STATIC pmemfile_test.cpp)
+target_link_libraries(pmemfile_test ${GTEST_LIBRARIES})
 add_library(test_backtrace STATIC ../test_backtrace.c)
-
-add_dependencies(pmemfile_test libgtest)
 
 add_cppstyle("tests-posix-test")
 add_check_whitespace("tests-posix-test" ${CMAKE_CURRENT_SOURCE_DIR}/*.*pp)
@@ -80,7 +62,7 @@ function(build_test name srcs)
 	add_cppstyle(tests-posix-${name} ${CMAKE_CURRENT_SOURCE_DIR}/${srcs})
 	add_check_whitespace(tests-posix-${name} ${CMAKE_CURRENT_SOURCE_DIR}/${srcs})
 	add_executable(${name} ${srcs})
-	target_link_libraries(${name} pmemfile-posix_shared pmemfile_test test_backtrace libgtest)
+	target_link_libraries(${name} pmemfile-posix_shared pmemfile_test test_backtrace)
 	if(LIBUNWIND_FOUND)
 		target_link_libraries(${name} ${LIBUNWIND_LIBRARIES} ${CMAKE_DL_LIBS})
 	endif()

--- a/tests/posix/gtest.cmake
+++ b/tests/posix/gtest.cmake
@@ -1,0 +1,79 @@
+option(USE_SYSTEM_GTEST "Use system installed gtest when set to ON, or build gtest locally when set to OFF" OFF)
+
+if(USE_SYSTEM_GTEST)
+  if( (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} VERSION_LESS 2.8) )
+    message( STATUS "Cmake version 2.8 or greater needed to use GTest" )
+  else()
+    # This will define GTEST_FOUND
+    find_package( GTest )
+  endif()
+else()
+  if(CMAKE_VERSION VERSION_LESS 3.2 AND CMAKE_GENERATOR MATCHES "Ninja")
+    message(WARNING "Building GTest with Ninja has known issues with CMake older than 3.2")
+  endif()
+
+  include(ExternalProject)
+
+  set(GTEST_LIBRARIES gtest gtest_main)
+  # the binary dir must be know before creating the external project in order
+  # to pass the byproducts
+  set(prefix "${CMAKE_CURRENT_BINARY_DIR}/gtest-external-prefix")
+  set(binary_dir "${prefix}/src/gtest-external-build")
+
+  set(byproducts)
+  foreach(lib ${GTEST_LIBRARIES})
+    set(${lib}_location
+      ${binary_dir}/${CMAKE_CFG_INTDIR}/googlemock/gtest/${CMAKE_STATIC_LIBRARY_PREFIX}${lib}${CMAKE_STATIC_LIBRARY_SUFFIX})
+    list(APPEND byproducts ${${lib}_location})
+  endforeach()
+
+  if( MSVC )
+	if( MSVC_VERSION LESS 1800 )  
+      set(EXTRA_FLAG "/D_VARIADIC_MAX=10 ")
+	else()
+	  set(EXTRA_FLAG "")
+	endif()
+  else()
+    set(EXTRA_FLAG "")
+  endif()
+  
+  ExternalProject_Add(
+    gtest-external
+    URL https://github.com/google/googletest/archive/release-1.8.0.zip
+    URL_MD5 adfafc8512ab65fd3cf7955ef0100ff5
+    PREFIX ${prefix}
+    BINARY_DIR ${binary_dir}
+    DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}
+    CMAKE_CACHE_ARGS
+      -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
+      -DCMAKE_CXX_FLAGS_DEBUG:STRING=${EXTRA_FLAG}${CMAKE_CXX_FLAGS_DEBUG}
+      -DCMAKE_CXX_FLAGS_MINSIZEREL:STRING=${EXTRA_FLAG}${CMAKE_CXX_FLAGS_MINSIZEREL}
+      -DCMAKE_CXX_FLAGS_RELEASE:STRING=${EXTRA_FLAG}${CMAKE_CXX_FLAGS_RELEASE}
+      -DCMAKE_CXX_FLAGS_RELWITHDEBINFO:STRING=${EXTRA_FLAG}${CMAKE_CXX_FLAGS_RELWITHDEBINFO}
+      -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
+      -DCMAKE_C_FLAGS_DEBUG:STRING=${CMAKE_C_FLAGS_DEBUG}
+      -DCMAKE_C_FLAGS_MINSIZEREL:STRING=${CMAKE_C_FLAGS_MINSIZEREL}
+      -DCMAKE_C_FLAGS_RELEASE:STRING=${CMAKE_C_FLAGS_RELEASE}
+      -DCMAKE_C_FLAGS_RELWITHDEBINFO:STRING=${CMAKE_C_FLAGS_RELWITHDEBINFO}
+      -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+      -Dgtest_force_shared_crt:BOOL=ON
+    BUILD_BYPRODUCTS ${byproducts}
+    INSTALL_COMMAND "")
+
+  foreach(lib ${GTEST_LIBRARIES})
+    add_library(${lib} IMPORTED STATIC)
+    add_dependencies(${lib} gtest-external)
+    set_target_properties(${lib} PROPERTIES
+	IMPORTED_LOCATION ${${lib}_location}
+        IMPORTED_LINK_INTERFACE_LIBRARIES "${CMAKE_THREAD_LIBS_INIT}")
+  endforeach()
+
+  ExternalProject_Get_Property(gtest-external source_dir)
+  set(GTEST_INCLUDE_DIRS ${source_dir}/googletest/include)
+  set(GTEST_FOUND ON)
+endif()
+
+# Hack to get googletest v1.6 to work with vs2012
+if( MSVC11 )
+  add_definitions( "/D_VARIADIC_MAX=10" )
+endif( )


### PR DESCRIPTION
Add a new cmake file called gtest.cmake, based on
https://github.com/clMathLibraries/clFFT/blob/master/src/gtest.cmake

fixes #144

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/146)
<!-- Reviewable:end -->
