### PR TITLE
posix: make it possible to unlink file when fs is full

### DIFF
--- a/src/libpmemfile-posix/inode.h
+++ b/src/libpmemfile-posix/inode.h
@@ -125,6 +125,7 @@ TOID(struct pmemfile_inode) inode_alloc(PMEMfilepool *pfp,
 		struct pmemfile_cred *cred, uint64_t flags);
 
 void inode_free(PMEMfilepool *pfp, TOID(struct pmemfile_inode) tinode);
+void inode_trim(PMEMfilepool *pfp, TOID(struct pmemfile_inode) tinode);
 
 struct pmemfile_vinode *vinode_ref(PMEMfilepool *pfp,
 		struct pmemfile_vinode *vinode);


### PR DESCRIPTION
I also refactored unref to open a transaction only when ref count
and nlink count drop to 0. It speeds up tests under pmemcheck.

Ref: pmem/issues#553

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/165)
<!-- Reviewable:end -->
