### PR TITLE
posix: fix error handling in pool open/create

### DIFF
--- a/src/libpmemfile-posix/pool.c
+++ b/src/libpmemfile-posix/pool.c
@@ -104,15 +104,19 @@ initialize_super_block(PMEMfilepool *pfp)
 		} TX_ONABORT {
 			error = errno;
 		} TX_END
+
+		if (error) {
+			ERR("!cannot initialize super block");
+			goto tx_err;
+		}
 	}
 
 	pfp->root = inode_ref(pfp, super->root_inode, NULL, NULL, 0);
-	if (!pfp->root)
+	if (!pfp->root) {
 		error = errno;
 
-	if (error) {
-		ERR("!cannot initialize super block");
-		goto tx_err;
+		ERR("!cannot access root inode");
+		goto ref_err;
 	}
 
 	pfp->root->parent = pfp->root;
@@ -125,6 +129,7 @@ initialize_super_block(PMEMfilepool *pfp)
 	cred_release(&cred);
 
 	return 0;
+ref_err:
 tx_err:
 	inode_map_free(pfp);
 inode_map_alloc_fail:


### PR DESCRIPTION
We were calling inode_ref even if previous transaction failed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/168)
<!-- Reviewable:end -->
