### PR TITLE
preload: improve one confusing comment

### DIFF
--- a/src/libpmemfile/path_resolve.c
+++ b/src/libpmemfile/path_resolve.c
@@ -300,8 +300,7 @@ resolve_path(struct fd_desc at,
 
 	/*
 	 * XXX
-	 * This code is too convoluted, and new bugs are found in it weekly.
-	 * Must be rewritten after the holidays.
+	 * Path resolution needs more tests.
 	 */
 	for (resolved = strspn(result->path, "/");
 	    result->path[resolved] != '\0' && result->error_code == 0;


### PR DESCRIPTION
I started refactoring path resolution code, (https://github.com/GBuella/pmemfile/commits/path_resolve_refactor), to make it more readable/maintainable, but I'm afraid it will take some more days. So for now, I just removed the related confusing comment in `path_resolve.c`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/169)
<!-- Reviewable:end -->
