### PR TITLE
posix: fix possible memory leak in [f]truncate + some cleanups

### DIFF
--- a/src/libpmemfile-posix/data.c
+++ b/src/libpmemfile-posix/data.c
@@ -163,25 +163,6 @@ find_closest_block_with_hint(struct pmemfile_vinode *vinode, uint64_t offset,
 }
 
 /*
- * vinode_destroy_data_state -- destroys file state related to data
- *
- * This is used as a callback passed to cb_push_front, that is why the pfp
- * argument is used.
- */
-void
-vinode_destroy_data_state(PMEMfilepool *pfp, struct pmemfile_vinode *vinode)
-{
-	(void) pfp;
-
-	if (vinode->blocks) {
-		ctree_delete(vinode->blocks);
-		vinode->blocks = NULL;
-	}
-
-	memset(&vinode->first_free_block, 0, sizeof(vinode->first_free_block));
-}
-
-/*
  * file_allocate_block_data -- allocates new block data.
  * The block metadata must be already allocated, and passed as the block
  * pointer argument.

--- a/src/libpmemfile-posix/data.h
+++ b/src/libpmemfile-posix/data.h
@@ -39,8 +39,6 @@ extern bool pmemfile_overallocate_on_append;
 
 void vinode_destroy_data_state(PMEMfilepool *pfp,
 			struct pmemfile_vinode *vinode);
-void vinode_truncate(PMEMfilepool *pfp, struct pmemfile_vinode *vinode,
-			uint64_t size);
 
 int vinode_rebuild_block_tree(struct pmemfile_vinode *vinode);
 void vinode_remove_interval(struct pmemfile_vinode *vinode,

--- a/src/libpmemfile-posix/data.h
+++ b/src/libpmemfile-posix/data.h
@@ -37,9 +37,6 @@
 extern size_t pmemfile_posix_block_size;
 extern bool pmemfile_overallocate_on_append;
 
-void vinode_destroy_data_state(PMEMfilepool *pfp,
-			struct pmemfile_vinode *vinode);
-
 int vinode_rebuild_block_tree(struct pmemfile_vinode *vinode);
 void vinode_remove_interval(struct pmemfile_vinode *vinode,
 			uint64_t offset, uint64_t len);

--- a/src/libpmemfile-posix/file.c
+++ b/src/libpmemfile-posix/file.c
@@ -421,11 +421,7 @@ _pmemfile_openat(PMEMfilepool *pfp, struct pmemfile_vinode *dir,
 	} else if (flags & PMEMFILE_O_TRUNC) {
 		os_rwlock_wrlock(&vinode->rwlock);
 
-		TX_BEGIN_CB(pfp->pop, cb_queue, pfp) {
-			vinode_truncate(pfp, vinode, 0);
-		} TX_ONABORT {
-			error = errno;
-		} TX_END
+		error = vinode_truncate(pfp, vinode, 0);
 
 		os_rwlock_unlock(&vinode->rwlock);
 	}

--- a/src/libpmemfile-posix/inode.c
+++ b/src/libpmemfile-posix/inode.c
@@ -228,7 +228,8 @@ vinode_unref(PMEMfilepool *pfp, struct pmemfile_vinode *vinode)
 					to_unregister))
 				FATAL("vinode not found");
 
-			vinode_destroy_data_state(pfp, to_unregister);
+			if (to_unregister->blocks)
+				ctree_delete(to_unregister->blocks);
 
 #ifdef DEBUG
 			/* "path" field is defined only in DEBUG builds */

--- a/src/libpmemfile-posix/truncate.c
+++ b/src/libpmemfile-posix/truncate.c
@@ -71,10 +71,6 @@ vinode_truncate(PMEMfilepool *pfp, struct pmemfile_vinode *vinode,
 	vinode_snapshot(vinode);
 
 	TX_BEGIN_CB(pfp->pop, cb_queue, pfp) {
-		cb_push_front(TX_STAGE_ONABORT,
-			(cb_basic)vinode_destroy_data_state,
-			vinode);
-
 		/*
 		 * Might need to handle the special case where size == 0.
 		 * Setting all the next and prev fields is pointless, when all

--- a/src/libpmemfile-posix/truncate.c
+++ b/src/libpmemfile-posix/truncate.c
@@ -50,67 +50,69 @@
 /*
  * vinode_truncate -- changes file size to size
  *
- * Should only be called inside pmemobj transactions.
+ * Should only be called without pmemobj transaction.
  */
-void
+int
 vinode_truncate(PMEMfilepool *pfp, struct pmemfile_vinode *vinode,
 		uint64_t size)
 {
 	struct pmemfile_inode *inode = vinode->inode;
 
-	ASSERT_IN_TX();
+	ASSERT_NOT_IN_TX();
 
 	if (vinode->blocks == NULL) {
 		int err = vinode_rebuild_block_tree(vinode);
 		if (err)
-			pmemfile_tx_abort(err);
+			return err;
 	}
 
-	cb_push_front(TX_STAGE_ONABORT,
-		(cb_basic)vinode_destroy_data_state,
-		vinode);
+	int error = 0;
 
-	/*
-	 * Might need to handle the special case where size == 0.
-	 * Setting all the next and prev fields is pointless, when all the
-	 * blocks are removed.
-	 */
-	vinode_remove_interval(vinode, size, UINT64_MAX - size);
-	if (inode->size < size)
-		vinode_allocate_interval(pfp, vinode,
-		    inode->size, size - inode->size);
+	vinode_snapshot(vinode);
 
-	if (inode->size != size) {
-		TX_ADD_DIRECT(&inode->size);
-		inode->size = size;
+	TX_BEGIN_CB(pfp->pop, cb_queue, pfp) {
+		cb_push_front(TX_STAGE_ONABORT,
+			(cb_basic)vinode_destroy_data_state,
+			vinode);
 
-		struct pmemfile_time tm;
-		get_current_time(&tm);
-		TX_SET_DIRECT(inode, mtime, tm);
-	}
+		/*
+		 * Might need to handle the special case where size == 0.
+		 * Setting all the next and prev fields is pointless, when all
+		 * the blocks are removed.
+		 */
+		vinode_remove_interval(vinode, size, UINT64_MAX - size);
+		if (inode->size < size)
+			vinode_allocate_interval(pfp, vinode,
+			    inode->size, size - inode->size);
+
+		if (inode->size != size) {
+			TX_ADD_DIRECT(&inode->size);
+			inode->size = size;
+
+			struct pmemfile_time tm;
+			get_current_time(&tm);
+			TX_SET_DIRECT(inode, mtime, tm);
+		}
+	} TX_ONABORT {
+		error = errno;
+		vinode_restore_on_abort(vinode);
+	} TX_END
+
+	return error;
 }
 
 static int
 _pmemfile_ftruncate(PMEMfilepool *pfp, struct pmemfile_vinode *vinode,
 			uint64_t length)
 {
+	ASSERT_NOT_IN_TX();
+
 	if (!vinode_is_regular_file(vinode))
 		return EINVAL;
 
-	int error = 0;
-
 	os_rwlock_wrlock(&vinode->rwlock);
 
-	vinode_snapshot(vinode);
-
-	ASSERT_NOT_IN_TX();
-
-	TX_BEGIN_CB(pfp->pop, cb_queue, pfp) {
-		vinode_truncate(pfp, vinode, length);
-	} TX_ONABORT {
-		error = errno;
-		vinode_restore_on_abort(vinode);
-	} TX_END
+	int error = vinode_truncate(pfp, vinode, length);
 
 	os_rwlock_unlock(&vinode->rwlock);
 

--- a/src/libpmemfile-posix/truncate.h
+++ b/src/libpmemfile-posix/truncate.h
@@ -35,7 +35,7 @@
 #include "inode.h"
 #include "pool.h"
 
-void vinode_truncate(PMEMfilepool *pfp, struct pmemfile_vinode *vinode,
+int vinode_truncate(PMEMfilepool *pfp, struct pmemfile_vinode *vinode,
 			uint64_t size);
 
 #endif


### PR DESCRIPTION
vinode_rebuild_block_tree when called from [f]truncate could allocate
a ctree, but fail at inserting time, which means ctree would leak.

Do all rebuilds outside of transaction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/193)
<!-- Reviewable:end -->
