### PR TITLE
Disabled dangling else warning for tests on GCC7

### DIFF
--- a/tests/posix/CMakeLists.txt
+++ b/tests/posix/CMakeLists.txt
@@ -31,6 +31,10 @@
 
 add_c_flag(-fno-strict-aliasing)
 
+# GTest macros trigger this warning with GCC7. The code is correct
+# but looks suspicious to GCC.
+add_flag(-Wno-dangling-else)
+
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 include(FindThreads)


### PR DESCRIPTION
GCC7 introduces new warning called 'Dangling else", due to probable bug in GTest using its functions causes  "dangling else" warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/196)
<!-- Reviewable:end -->
