### PR TITLE
preload: finish wiring up creat syscall

### DIFF
--- a/src/libpmemfile/syscall_early_filter.c
+++ b/src/libpmemfile/syscall_early_filter.c
@@ -60,6 +60,11 @@ static struct syscall_early_filter_entry filter_table[] = {
 		.fd_first_arg = true,
 		.fd_wlock = true,
 	},
+	[SYS_creat] = {
+		.must_handle = true,
+		.cwd_rlock = true,
+		.fd_wlock = true,
+	},
 	[SYS_faccessat] = {
 		.must_handle = true,
 		.cwd_rlock = true,


### PR DESCRIPTION
Apparently none of the applications we tested so far used this syscall.
Some versions of "vi" do.

Reported-by: Mateusz Szychowski

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/201)
<!-- Reviewable:end -->
