### PR TITLE
cmake: allow sanitizers with libpmemfile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,11 +210,12 @@ add_flag("-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2" RELEASE)
 
 add_flag(-D_LARGEFILE64_SOURCE)
 
-option(SANITIZERS "enable AddressSanitizer and UndefinedBehaviorSanitizer (debugging) (incompatible with BUILD_LIBPMEMFILE=ON)" OFF)
+option(SANITIZERS "enable AddressSanitizer and UndefinedBehaviorSanitizer (debugging) (using with BUILD_LIBPMEMFILE=ON is experimental)" OFF)
+set(SANITIZERS_PRELOAD "" CACHE STRING "(experimental) path to preloadable lib for sanitizers e.g.: /usr/lib/gcc/x86_64-linux-gnu/6/libasan.so")
 
 if(SANITIZERS)
 	if(BUILD_LIBPMEMFILE)
-		message(FATAL_ERROR "Sanitizers are incompatible with LIBPMEMFILE. If you want to test LIBPMEMFILE-POSIX with SANITIZERS define BUILD_LIBPMEMFILE to 0/OFF.")
+		message(WARNING "Sanitizers might be incompatible with LIBPMEMFILE. Running tests with SANITIZERS and BUILD_LIBPMEMFILE is experimental")
 	endif()
 
 	set(SAVED_CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES})

--- a/tests/preload/CMakeLists.txt
+++ b/tests/preload/CMakeLists.txt
@@ -44,8 +44,21 @@ add_check_whitespace(tests-preload-pool-locking ${CMAKE_CURRENT_SOURCE_DIR}/pool
 add_library(setumask SHARED setumask.c)
 set_target_properties(setumask PROPERTIES INCLUDE_DIRECTORIES ${CMAKE_SOURCE_DIR}/src)
 
-find_package(Threads REQUIRED)
 target_link_libraries(preload_pool_locking "${CMAKE_THREAD_LIBS_INIT}")
+
+set(PRELOAD_LIB_LIST $<TARGET_FILE:pmemfile_shared>:$<TARGET_FILE:setumask>)
+if(SANITIZERS)
+#
+# Some of these tests use executables on the system which are built without
+# sanitizer flags, and therefore libasan must be preloaded.
+#
+# The ASAN library must come first among the libraries, otherwise one might
+# greeted by an error message such as:
+#
+# "ASan runtime does not come first in initial library list; you should
+# either link runtime to your application or manually preload it with LD_PRELOAD."
+	set(PRELOAD_LIB_LIST ${SANITIZERS_PRELOAD}:${PRELOAD_LIB_LIST})
+endif()
 
 # Configures test ${name}${sub_name} using test dir ${name} and executable ${main_executable}
 function(add_test_generic name sub_name main_executable)
@@ -55,7 +68,7 @@ function(add_test_generic name sub_name main_executable)
 			-DTEST_NAME=${name}${sub_name}
 			-DSRC_DIR=${CMAKE_CURRENT_SOURCE_DIR}/${name}${sub_name}
 			-DBIN_DIR=${CMAKE_CURRENT_BINARY_DIR}/${name}${sub_name}
-			-DPRELOAD_LIB=$<TARGET_FILE:pmemfile_shared>:$<TARGET_FILE:setumask>
+			-DPRELOAD_LIB=${PRELOAD_LIB_LIST}
 			-DMAIN_EXECUTABLE=${main_executable}
 			${ARGN}
 			-P ${CMAKE_CURRENT_SOURCE_DIR}/${name}/${name}.cmake)


### PR DESCRIPTION
Still experimental, and the results are usually just segfaults.
Usage:

```
mkdir build
CC=gcc CXX=g++ cmake -DSANITIZERS=ON -DSANITIZERS_PRELOAD=/usr/lib/gcc/x86_64-linux-gnu/6/libasan.so -DBUILD_LIBPMEMFILE=ON ..
make
INTERCEPT_ALL_OBJS=1 ctest -R preload
```

The INTERCEPT_ALL_OBJS is likely required for such tests, so if it turns out that
it cannot work without it, it will be added to preload/CMakeLists.txt in another commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/233)
<!-- Reviewable:end -->
