### PR TITLE
cmake: Introduce USE_ASAN and USE_UBSAN options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,32 +210,40 @@ add_flag("-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2" RELEASE)
 
 add_flag(-D_LARGEFILE64_SOURCE)
 
-option(SANITIZERS "enable AddressSanitizer and UndefinedBehaviorSanitizer (debugging) (using with BUILD_LIBPMEMFILE=ON is experimental)" OFF)
-set(SANITIZERS_PRELOAD "" CACHE STRING "(experimental) path to preloadable lib for sanitizers e.g.: /usr/lib/gcc/x86_64-linux-gnu/6/libasan.so")
+option(USE_ASAN "enable AddressSanitizer (debugging) (using with BUILD_LIBPMEMFILE=ON is experimental)" OFF)
+option(USE_UBSAN "enable UndefinedBehaviorSanitizer (debugging) (using with BUILD_LIBPMEMFILE=ON is experimental)" OFF)
+set(ASAN_RUNTIME "" CACHE STRING "(experimental) path to preloadable lib for sanitizers e.g.: /usr/lib/gcc/x86_64-linux-gnu/6/libasan.so")
 
-if(SANITIZERS)
+macro(add_sanitizer_flag flag)
 	if(BUILD_LIBPMEMFILE)
-		message(WARNING "Sanitizers might be incompatible with LIBPMEMFILE. Running tests with SANITIZERS and BUILD_LIBPMEMFILE is experimental")
+		message(WARNING "Sanitizers might be incompatible with LIBPMEMFILE. Running tests with sanitizers and BUILD_LIBPMEMFILE is experimental")
 	endif()
 
 	set(SAVED_CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES})
-	set(CMAKE_REQUIRED_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES} -fsanitize=address,undefined")
+	set(CMAKE_REQUIRED_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES} -fsanitize=${flag}")
 
-	check_c_compiler_flag("-fsanitize=address,undefined" C_HAS_ASAN_UBSAN)
+	check_c_compiler_flag("-fsanitize=${flag}" C_HAS_ASAN_UBSAN)
 	if(C_HAS_ASAN_UBSAN)
-		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address,undefined")
+		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=${flag}")
 	endif()
 
-	check_cxx_compiler_flag("-fsanitize=address,undefined" CXX_HAS_ASAN_UBSAN)
+	check_cxx_compiler_flag("-fsanitize=${flag}" CXX_HAS_ASAN_UBSAN)
 	if(CXX_HAS_ASAN_UBSAN)
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address,undefined")
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=${flag}")
 	endif()
 
 	if(C_HAS_ASAN_UBSAN OR CXX_HAS_ASAN_UBSAN)
-		set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address,undefined")
+		set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=${flag}")
 	endif()
 
 	set(CMAKE_REQUIRED_LIBRARIES ${SAVED_CMAKE_REQUIRED_LIBRARIES})
+endmacro()
+
+if(USE_ASAN)
+	add_sanitizer_flag(address)
+endif()
+if(USE_UBSAN)
+	add_sanitizer_flag(undefined)
 endif()
 
 if(DEVELOPER_MODE)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Pmemfile-specific cmake variables:
 * TEST_DIR=/mnt/pmem/test_dir - provides directory where tests will create its pools
 * TRACE_TESTS=1 - dumps more info when test fails (requires cmake >= 3.4)
 * TESTS_USE_FORCED_PMEM=1 - allows tests to force enable or force disable use of optimized flush in libpmemobj (to speed them up)
-* SANITIZERS=1 - enables AddressSanitizer and UndefinedBehaviorSanitizer (only for debugging)
+* USE_ASAN=1 - enables AddressSanitizer (only for debugging)
+* USE_UBSAN=1 - enables UndefinedBehaviorSanitizer (only for debugging)
 
 # Package for Debian-based distros
 ```sh

--- a/tests/posix/CMakeLists.txt
+++ b/tests/posix/CMakeLists.txt
@@ -141,7 +141,7 @@ function(add_test_with_filter name filter tracer)
 		endif()
 	endif()
 
-	if (SANITIZERS AND ${tracer} IN_LIST vg_tracers)
+	if ((USE_ASAN OR USE_UBSAN) AND ${tracer} IN_LIST vg_tracers)
 		return()
 	endif()
 

--- a/tests/preload/CMakeLists.txt
+++ b/tests/preload/CMakeLists.txt
@@ -47,7 +47,7 @@ set_target_properties(setumask PROPERTIES INCLUDE_DIRECTORIES ${CMAKE_SOURCE_DIR
 target_link_libraries(preload_pool_locking "${CMAKE_THREAD_LIBS_INIT}")
 
 set(PRELOAD_LIB_LIST $<TARGET_FILE:pmemfile_shared>:$<TARGET_FILE:setumask>)
-if(SANITIZERS)
+if(USE_ASAN)
 #
 # Some of these tests use executables on the system which are built without
 # sanitizer flags, and therefore libasan must be preloaded.
@@ -57,7 +57,7 @@ if(SANITIZERS)
 #
 # "ASan runtime does not come first in initial library list; you should
 # either link runtime to your application or manually preload it with LD_PRELOAD."
-	set(PRELOAD_LIB_LIST ${SANITIZERS_PRELOAD}:${PRELOAD_LIB_LIST})
+	set(PRELOAD_LIB_LIST ${ASAN_RUNTIME}:${PRELOAD_LIB_LIST})
 endif()
 
 # Configures test ${name}${sub_name} using test dir ${name} and executable ${main_executable}


### PR DESCRIPTION
Replacing the SANITIZERS option.

This helped me run sanitizers with gcc builds on my desktop. Using the original sanitizers flag resulted in a "stack-buffer-underflow" error being detected by ASAN -- about which (after looking at the instructions around the code being reported) I suspected might be the result of a conflict between ASAN and UBSAN instrumentation. I don't know if it really was or not, but it does disappear when using ASAN only, so I think this patch can be useful.

BTW the error reported by ASAN:
```
=================================================================
==20913==ERROR: AddressSanitizer: stack-buffer-underflow on address 0x7fff6dea785c at pc 0x7f6d78037d1d bp 0x7fff6dea7830 sp 0x7fff6dea7820
READ of size 4 at 0x7fff6dea785c thread T0
    #0 0x7f6d78037d1c in can_access /home/tej/code/pmemfile/src/libpmemfile-posix/creds.c:461
    #1 0x7f6d78037ece in _vinode_can_access /home/tej/code/pmemfile/src/libpmemfile-posix/creds.c:505
    #2 0x7f6d7805de05 in pmemfile_rmdirat /home/tej/code/pmemfile/src/libpmemfile-posix/rmdir.c:196
    #3 0x7f6d7805e312 in pmemfile_rmdir /home/tej/code/pmemfile/src/libpmemfile-posix/rmdir.c:248
    #4 0x55688c8d3d2d in dirs_mkdir_rmdir_unlink_errors_Test::TestBody() /home/tej/code/pmemfile/tests/posix/dirs/dirs.cpp:359
    #5 0x55688c9d9e83 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/tej/code/pmemfile/build/tests/posix/gtest/src/gtest/googletest/src/gtest.cc:2402
    #6 0x55688c9d9e83 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/tej/code/pmemfile/build/tests/posix/gtest/src/gtest/googletest/src/gtest.cc:2438
    #7 0x55688c9cfd90 in testing::Test::Run() /home/tej/code/pmemfile/build/tests/posix/gtest/src/gtest/googletest/src/gtest.cc:2475
    #8 0x55688c9d001c in testing::Test::Run() /home/tej/code/pmemfile/build/tests/posix/gtest/src/gtest/googletest/src/gtest.cc:2466
    #9 0x55688c9d001c in testing::TestInfo::Run() /home/tej/code/pmemfile/build/tests/posix/gtest/src/gtest/googletest/src/gtest.cc:2656
    #10 0x55688c9d01f4 in testing::TestInfo::Run() /home/tej/code/pmemfile/build/tests/posix/gtest/src/gtest/googletest/src/gtest.cc:2631
    #11 0x55688c9d01f4 in testing::TestCase::Run() /home/tej/code/pmemfile/build/tests/posix/gtest/src/gtest/googletest/src/gtest.cc:2774
    #12 0x55688c9d06f4 in testing::TestCase::Run() /home/tej/code/pmemfile/build/tests/posix/gtest/src/gtest/googletest/src/gtest.cc:4687
    #13 0x55688c9d06f4 in testing::internal::UnitTestImpl::RunAllTests() /home/tej/code/pmemfile/build/tests/posix/gtest/src/gtest/googletest/src/gtest.cc:4649
    #14 0x55688c9da333 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/tej/code/pmemfile/build/tests/posix/gtest/src/gtest/googletest/src/gtest.cc:2402
    #15 0x55688c9da333 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/tej/code/pmemfile/build/tests/posix/gtest/src/gtest/googletest/src/gtest.cc:2438
    #16 0x55688c9d0a38 in testing::UnitTest::Run() /home/tej/code/pmemfile/build/tests/posix/gtest/src/gtest/googletest/src/gtest.cc:4257
    #17 0x55688c8a04b8 in RUN_ALL_TESTS() tests/posix/gtest/src/gtest/googletest/include/gtest/gtest.h:2233
    #18 0x55688c8a04b8 in main /home/tej/code/pmemfile/tests/posix/dirs/dirs.cpp:1853
    #19 0x7f6d765633f0 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x203f0)
    #20 0x55688c8a0ad9 in _start (/home/tej/code/pmemfile/build/tests/posix/file_dirs+0x20ead9)

Address 0x7fff6dea785c is located in stack of thread T0==20913==AddressSanitizer CHECK failed: ../../../../src/libsanitizer/asan/asan_thread.cc:243 "((ptr[0] == kCurrentStackFrameMagic)) != (0)" (0x0, 0x0)
    #0 0x7f6d7839680a  (/usr/lib/x86_64-linux-gnu/libasan.so.3+0xd080a)
    #1 0x7f6d7839d1d3 in __sanitizer::CheckFailed(char const*, int, char const*, unsigned long long, unsigned long long) (/usr/lib/x86_64-linux-gnu/libasan.so.3+0xd71d3)
    #2 0x7f6d7839ae11  (/usr/lib/x86_64-linux-gnu/libasan.so.3+0xd4e11)
    #3 0x7f6d7839223a  (/usr/lib/x86_64-linux-gnu/libasan.so.3+0xcc23a)
    #4 0x7f6d7839280a  (/usr/lib/x86_64-linux-gnu/libasan.so.3+0xcc80a)
    #5 0x7f6d78395c69  (/usr/lib/x86_64-linux-gnu/libasan.so.3+0xcfc69)
    #6 0x7f6d78396d26 in __asan_report_load4 (/usr/lib/x86_64-linux-gnu/libasan.so.3+0xd0d26)
    #7 0x7f6d78037d1c in can_access /home/tej/code/pmemfile/src/libpmemfile-posix/creds.c:461
    #8 0x7f6d78037ece in _vinode_can_access /home/tej/code/pmemfile/src/libpmemfile-posix/creds.c:505
    #9 0x7f6d7805de05 in pmemfile_rmdirat /home/tej/code/pmemfile/src/libpmemfile-posix/rmdir.c:196
    #10 0x7f6d7805e312 in pmemfile_rmdir /home/tej/code/pmemfile/src/libpmemfile-posix/rmdir.c:248
    #11 0x55688c8d3d2d in dirs_mkdir_rmdir_unlink_errors_Test::TestBody() /home/tej/code/pmemfile/tests/posix/dirs/dirs.cpp:359
    #12 0x55688c9d9e83 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/tej/code/pmemfile/build/tests/posix/gtest/src/gtest/googletest/src/gtest.cc:2402
    #13 0x55688c9d9e83 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/tej/code/pmemfile/build/tests/posix/gtest/src/gtest/googletest/src/gtest.cc:2438
    #14 0x55688c9cfd90 in testing::Test::Run() /home/tej/code/pmemfile/build/tests/posix/gtest/src/gtest/googletest/src/gtest.cc:2475
    #15 0x55688c9d001c in testing::Test::Run() /home/tej/code/pmemfile/build/tests/posix/gtest/src/gtest/googletest/src/gtest.cc:2466
    #16 0x55688c9d001c in testing::TestInfo::Run() /home/tej/code/pmemfile/build/tests/posix/gtest/src/gtest/googletest/src/gtest.cc:2656
    #17 0x55688c9d01f4 in testing::TestInfo::Run() /home/tej/code/pmemfile/build/tests/posix/gtest/src/gtest/googletest/src/gtest.cc:2631
    #18 0x55688c9d01f4 in testing::TestCase::Run() /home/tej/code/pmemfile/build/tests/posix/gtest/src/gtest/googletest/src/gtest.cc:2774
    #19 0x55688c9d06f4 in testing::TestCase::Run() /home/tej/code/pmemfile/build/tests/posix/gtest/src/gtest/googletest/src/gtest.cc:4687
    #20 0x55688c9d06f4 in testing::internal::UnitTestImpl::RunAllTests() /home/tej/code/pmemfile/build/tests/posix/gtest/src/gtest/googletest/src/gtest.cc:4649
    #21 0x55688c9da333 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/tej/code/pmemfile/build/tests/posix/gtest/src/gtest/googletest/src/gtest.cc:2402
    #22 0x55688c9da333 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/tej/code/pmemfile/build/tests/posix/gtest/src/gtest/googletest/src/gtest.cc:2438
    #23 0x55688c9d0a38 in testing::UnitTest::Run() /home/tej/code/pmemfile/build/tests/posix/gtest/src/gtest/googletest/src/gtest.cc:4257
    #24 0x55688c8a04b8 in RUN_ALL_TESTS() tests/posix/gtest/src/gtest/googletest/include/gtest/gtest.h:2233
    #25 0x55688c8a04b8 in main /home/tej/code/pmemfile/tests/posix/dirs/dirs.cpp:1853
    #26 0x7f6d765633f0 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x203f0)
    #27 0x55688c8a0ad9 in _start (/home/tej/code/pmemfile/build/tests/posix/file_dirs+0x20ead9)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/235)
<!-- Reviewable:end -->
