### PR TITLE
posix: O_RDWR is not a valid flag to open directories

### DIFF
--- a/src/libpmemfile-posix/file.c
+++ b/src/libpmemfile-posix/file.c
@@ -338,6 +338,13 @@ _pmemfile_openat(PMEMfilepool *pfp, struct pmemfile_vinode *dir,
 			goto end;
 		}
 
+		if (((flags & PMEMFILE_O_ACCMODE) == PMEMFILE_O_WRONLY ||
+		    (flags & PMEMFILE_O_ACCMODE) == PMEMFILE_O_RDWR) &&
+		    vinode_is_dir(vinode)) {
+			error = EISDIR;
+			goto end;
+		}
+
 		if (flags & PMEMFILE_O_TRUNC) {
 			if (!vinode_is_regular_file(vinode)) {
 				LOG(LUSR, "truncating non regular file");

--- a/src/libpmemfile-posix/truncate.c
+++ b/src/libpmemfile-posix/truncate.c
@@ -139,6 +139,11 @@ pmemfile_ftruncate(PMEMfilepool *pfp, PMEMfile *file, pmemfile_off_t length)
 	struct pmemfile_vinode *vinode = file->vinode;
 	os_mutex_unlock(&file->mutex);
 
+	if (vinode_is_dir(vinode)) {
+		errno = EINVAL;
+		return -1;
+	}
+
 	if (!(flags & PFILE_WRITE)) {
 		errno = EBADF;
 		return -1;

--- a/tests/posix/basic/basic.cpp
+++ b/tests/posix/basic/basic.cpp
@@ -44,7 +44,7 @@ public:
 
 TEST_F(basic, open_create_close)
 {
-	PMEMfile *f1, *f2;
+	PMEMfile *f1, *f2, *dir;
 
 	/* NULL file name */
 	errno = 0;
@@ -130,6 +130,30 @@ TEST_F(basic, open_create_close)
 
 	ASSERT_EQ(pmemfile_unlink(pfp, "/aaa"), 0);
 	ASSERT_EQ(pmemfile_unlink(pfp, "/bbb"), 0);
+
+	/* make directory */
+	errno = 0;
+	ASSERT_EQ(pmemfile_mkdir(pfp, "/dir", 0777), 0);
+
+	/* successful open directory */
+	dir = pmemfile_open(pfp, "/dir",
+			    PMEMFILE_O_DIRECTORY | PMEMFILE_O_RDONLY);
+	ASSERT_NE(dir, nullptr);
+	pmemfile_close(pfp, dir);
+
+	/* wrong flags passed */
+	dir = pmemfile_open(pfp, "/dir",
+			    PMEMFILE_O_DIRECTORY | PMEMFILE_O_WRONLY);
+	ASSERT_EQ(dir, nullptr);
+	ASSERT_EQ(errno, EISDIR);
+
+	errno = 0;
+	dir = pmemfile_open(pfp, "/dir",
+			    PMEMFILE_O_DIRECTORY | PMEMFILE_O_RDWR);
+	ASSERT_EQ(dir, nullptr);
+	ASSERT_EQ(errno, EISDIR);
+
+	ASSERT_EQ(pmemfile_rmdir(pfp, "/dir"), 0);
 }
 
 TEST_F(basic, link)

--- a/tests/posix/dirs/dirs.cpp
+++ b/tests/posix/dirs/dirs.cpp
@@ -369,7 +369,7 @@ TEST_F(dirs, read_write_dir)
 	ASSERT_EQ(pmemfile_mkdir(pfp, "/dir", PMEMFILE_S_IRWXU), 0);
 
 	PMEMfile *dir = pmemfile_open(pfp, "/dir",
-				      PMEMFILE_O_DIRECTORY | PMEMFILE_O_RDWR);
+				      PMEMFILE_O_DIRECTORY | PMEMFILE_O_RDONLY);
 	ASSERT_NE(dir, nullptr);
 
 	char buf[10];

--- a/tests/posix/rw/rw.cpp
+++ b/tests/posix/rw/rw.cpp
@@ -626,7 +626,7 @@ TEST_F(rw, ftruncate)
 	ASSERT_EQ(pmemfile_unlink(pfp, "/file1"), 0);
 
 	ASSERT_EQ(pmemfile_mkdir(pfp, "/dir", 0777), 0);
-	f = pmemfile_open(pfp, "/dir", PMEMFILE_O_RDWR, 0);
+	f = pmemfile_open(pfp, "/dir", PMEMFILE_O_DIRECTORY, 0);
 	ASSERT_NE(f, nullptr);
 
 	errno = 0;


### PR DESCRIPTION
1. opening directory with O_RDWR flag should return -1 with EINVAL errno.
2. ftruncate needs to check if a directory was passed to it

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/236)
<!-- Reviewable:end -->
