### PR TITLE
preload: fix how paths crossing pmemfile mount point are handled

### DIFF
--- a/src/libpmemfile/preload.c
+++ b/src/libpmemfile/preload.c
@@ -1258,31 +1258,21 @@ hook_readlinkat(long fd, const char *path,
 }
 
 static long
-nosup_syscall_with_path(long syscall_number,
-			long path, int resolve_last,
-			long arg0, long arg1,
-			long arg2, long arg3,
-			long arg4, long arg5)
+nosup_syscall_with_path(long syscall_number, const char *path, int resolve_last,
+			long arg1, long arg2, long arg3, long arg4, long arg5)
 {
 	struct resolved_path where;
 
-	resolve_path(cwd_desc(), (const char *)path, &where, resolve_last);
+	resolve_path(cwd_desc(), path, &where, resolve_last | NO_AT_PATH);
 
 	if (where.error_code != 0)
 		return where.error_code;
 
-	/*
-	 * XXX only forward these to the kernel, if the path is not relative
-	 * to some fd. Normally, the _at version of the syscall would be used
-	 * here, i.e.: xxx_at(kernel_fd, path, ...), but some of these syscalls
-	 * don't have an _at version. So for now these are only handled, if the
-	 * path is relative to AT_FDCWD.
-	 */
-	if (is_fda_null(&where.at.pmem_fda) && where.at.kernel_fd == AT_FDCWD)
-		return syscall_no_intercept(syscall_number,
-		    arg0, arg1, arg2, arg3, arg4, arg5);
+	if (!is_fda_null(&where.at.pmem_fda))
+		return check_errno(-ENOTSUP, syscall_number);
 
-	return check_errno(-ENOTSUP, syscall_number);
+	return syscall_no_intercept(syscall_number, where.path, arg1, arg2,
+			arg3, arg4, arg5);
 }
 
 static long
@@ -2015,7 +2005,7 @@ dispatch_syscall(long syscall_number,
 		return hook_umask((mode_t)arg0);
 
 	/*
-	 * Some syscalls that have a path argument, but are not ( yet ) handled
+	 * Some syscalls that have a path argument, but are not (yet) handled
 	 * by libpmemfile-posix. The argument of these are not interpreted,
 	 * except for the path itself. If the path points to something pmemfile
 	 * resident, -ENOTSUP is returned, otherwise, the call is forwarded
@@ -2025,14 +2015,14 @@ dispatch_syscall(long syscall_number,
 	case SYS_listxattr:
 	case SYS_removexattr:
 		return nosup_syscall_with_path(syscall_number,
-		    arg0, RESOLVE_LAST_SLINK,
-		    arg0, arg1, arg2, arg3, arg4, arg5);
+		    (const char *)arg0, RESOLVE_LAST_SLINK,
+		    arg1, arg2, arg3, arg4, arg5);
 
 	case SYS_llistxattr:
 	case SYS_lremovexattr:
 		return nosup_syscall_with_path(syscall_number,
-		    arg0, NO_RESOLVE_LAST_SLINK,
-		    arg0, arg1, arg2, arg3, arg4, arg5);
+		    (const char *)arg0, NO_RESOLVE_LAST_SLINK,
+		    arg1, arg2, arg3, arg4, arg5);
 
 	case SYS_readlink:
 		return hook_readlinkat(AT_FDCWD, (const char *)arg0,

--- a/src/libpmemfile/preload.c
+++ b/src/libpmemfile/preload.c
@@ -56,8 +56,10 @@
 #include <setjmp.h>
 #include <pthread.h>
 #include <unistd.h>
+#include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/un.h>
 #include <stdio.h>
 #include <limits.h>
 #include <linux/fs.h>
@@ -1824,6 +1826,45 @@ hook_umask(mode_t mask)
 }
 
 static long
+hook_bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
+{
+	if (addr->sa_family != AF_UNIX ||
+			addrlen < sizeof(struct sockaddr_un)) {
+		return syscall_no_intercept(SYS_bind, sockfd, addr, addrlen);
+	}
+
+	const struct sockaddr_un *uaddr = (struct sockaddr_un *)addr;
+
+	struct resolved_path where;
+
+	struct fd_desc at = cwd_desc();
+
+	resolve_path(at, uaddr->sun_path, &where,
+			NO_RESOLVE_LAST_SLINK | NO_AT_PATH);
+
+	if (where.error_code != 0)
+		return where.error_code;
+
+	if (!is_fda_null(&where.at.pmem_fda))
+		return check_errno(-ENOTSUP, SYS_bind);
+
+	struct sockaddr_un tmp_uaddr;
+
+	tmp_uaddr.sun_family = AF_UNIX;
+
+	size_t len = strlen(where.path);
+
+	if (len >= sizeof(tmp_uaddr.sun_path))
+		return -ENAMETOOLONG;
+
+	strncpy(tmp_uaddr.sun_path, where.path, len);
+	tmp_uaddr.sun_path[len] = 0;
+
+	return syscall_no_intercept(SYS_bind, sockfd, &tmp_uaddr,
+			sizeof(tmp_uaddr));
+}
+
+static long
 dispatch_syscall(long syscall_number,
 			long arg0, long arg1,
 			long arg2, long arg3,
@@ -2067,6 +2108,10 @@ dispatch_syscall(long syscall_number,
 	case SYS_copy_file_range:
 		return hook_copy_file_range(arg0, (loff_t *)arg1,
 		    arg2, (loff_t *)arg3, (size_t)arg4, (unsigned)arg5);
+
+	case SYS_bind:
+		return hook_bind((int)arg0, (const struct sockaddr *)arg1,
+				(socklen_t)arg2);
 
 	default:
 		/* Did we miss something? */

--- a/src/libpmemfile/preload.c
+++ b/src/libpmemfile/preload.c
@@ -809,7 +809,7 @@ hook_getxattr(long arg0, long arg1, long arg2, long arg3,
 		return where.error_code;
 
 	if (is_fda_null(&where.at.pmem_fda)) {
-		if (where.at.kernel_fd == AT_FDCWD)
+		if (where.at.kernel_fd != AT_FDCWD)
 			return check_errno(-ENOTSUP, SYS_getxattr); /* XXX */
 
 		return syscall_no_intercept(SYS_getxattr,
@@ -833,7 +833,7 @@ hook_setxattr(long arg0, long arg1, long arg2, long arg3, long arg4,
 	if (!is_fda_null(&where.at.pmem_fda))
 		return check_errno(-ENOTSUP, SYS_setxattr);
 
-	if (where.at.kernel_fd == AT_FDCWD)
+	if (where.at.kernel_fd != AT_FDCWD)
 		return check_errno(-ENOTSUP, SYS_setxattr); /* XXX */
 
 	return syscall_no_intercept(SYS_setxattr, where.path, arg1, arg2, arg3,

--- a/src/libpmemfile/preload.h
+++ b/src/libpmemfile/preload.h
@@ -87,6 +87,8 @@ struct pool_description {
 
 #define RESOLVE_LAST_SLINK 1
 #define NO_RESOLVE_LAST_SLINK 2
+#define RESOLVE_LAST_SLINK_MASK 3
+#define NO_AT_PATH (1<<30)
 
 struct pool_description *lookup_pd_by_inode(struct stat *stat);
 
@@ -129,6 +131,6 @@ struct resolved_path {
 void resolve_path(struct fd_desc at,
 			const char *path,
 			struct resolved_path *result,
-			int resolve_last_or_not);
+			int flags);
 
 #endif

--- a/src/libpmemfile/syscall_early_filter.c
+++ b/src/libpmemfile/syscall_early_filter.c
@@ -341,6 +341,10 @@ static struct syscall_early_filter_entry filter_table[] = {
 	},
 
 	/* Syscalls not handled yet */
+	[SYS_bind] = {
+		.must_handle = true,
+		.cwd_rlock = true,
+	},
 	[SYS_chroot] = {
 		.must_handle = true,
 		.cwd_rlock = true,

--- a/tests/preload/CMakeLists.txt
+++ b/tests/preload/CMakeLists.txt
@@ -33,16 +33,19 @@ add_executable(preload_basic basic/basic.c)
 add_executable(preload_config config/config.c)
 add_executable(preload_pool_locking pool_locking/pool_locking.c)
 add_executable(preload_xattr xattr/xattr.c)
+add_executable(preload_unix unix/unix.c)
 
 add_cstyle(tests-preload-basic ${CMAKE_CURRENT_SOURCE_DIR}/basic/basic.c)
 add_cstyle(tests-preload-config ${CMAKE_CURRENT_SOURCE_DIR}/config/config.c)
 add_cstyle(tests-preload-pool-locking ${CMAKE_CURRENT_SOURCE_DIR}/pool_locking/pool_locking.c)
 add_cstyle(tests-preload-xattr ${CMAKE_CURRENT_SOURCE_DIR}/xattr/xattr.c)
+add_cstyle(tests-preload-unix ${CMAKE_CURRENT_SOURCE_DIR}/unix/unix.c)
 
 add_check_whitespace(tests-preload-basic ${CMAKE_CURRENT_SOURCE_DIR}/basic/basic.c)
 add_check_whitespace(tests-preload-config ${CMAKE_CURRENT_SOURCE_DIR}/config/config.c)
 add_check_whitespace(tests-preload-pool-locking ${CMAKE_CURRENT_SOURCE_DIR}/pool_locking/pool_locking.c)
 add_check_whitespace(tests-preload-xattr ${CMAKE_CURRENT_SOURCE_DIR}/xattr/xattr.c)
+add_check_whitespace(tests-preload-unix ${CMAKE_CURRENT_SOURCE_DIR}/unix/unix.c)
 
 add_library(setumask SHARED setumask.c)
 set_target_properties(setumask PROPERTIES INCLUDE_DIRECTORIES ${CMAKE_SOURCE_DIR}/src)
@@ -121,3 +124,4 @@ set_tests_properties("preload_config_outer_via_invalid"
 	PROPERTIES PASS_REGULAR_EXPRESSION "EIO")
 
 add_test_generic(xattr "" $<TARGET_FILE:preload_xattr>)
+add_test_generic(unix "" $<TARGET_FILE:preload_unix>)

--- a/tests/preload/CMakeLists.txt
+++ b/tests/preload/CMakeLists.txt
@@ -32,14 +32,17 @@
 add_executable(preload_basic basic/basic.c)
 add_executable(preload_config config/config.c)
 add_executable(preload_pool_locking pool_locking/pool_locking.c)
+add_executable(preload_xattr xattr/xattr.c)
 
 add_cstyle(tests-preload-basic ${CMAKE_CURRENT_SOURCE_DIR}/basic/basic.c)
 add_cstyle(tests-preload-config ${CMAKE_CURRENT_SOURCE_DIR}/config/config.c)
 add_cstyle(tests-preload-pool-locking ${CMAKE_CURRENT_SOURCE_DIR}/pool_locking/pool_locking.c)
+add_cstyle(tests-preload-xattr ${CMAKE_CURRENT_SOURCE_DIR}/xattr/xattr.c)
 
 add_check_whitespace(tests-preload-basic ${CMAKE_CURRENT_SOURCE_DIR}/basic/basic.c)
 add_check_whitespace(tests-preload-config ${CMAKE_CURRENT_SOURCE_DIR}/config/config.c)
 add_check_whitespace(tests-preload-pool-locking ${CMAKE_CURRENT_SOURCE_DIR}/pool_locking/pool_locking.c)
+add_check_whitespace(tests-preload-xattr ${CMAKE_CURRENT_SOURCE_DIR}/xattr/xattr.c)
 
 add_library(setumask SHARED setumask.c)
 set_target_properties(setumask PROPERTIES INCLUDE_DIRECTORIES ${CMAKE_SOURCE_DIR}/src)
@@ -92,21 +95,29 @@ add_test_generic(pool_locking "" $<TARGET_FILE:preload_pool_locking>)
 add_test_generic(config "_valid_via_symlink" $<TARGET_FILE:preload_config> -DTEST_PATH=some_dir/some_link/a)
 set_tests_properties("preload_config_valid_via_symlink"
 	PROPERTIES PASS_REGULAR_EXPRESSION "no error")
+
 add_test_generic(config "_invalid" $<TARGET_FILE:preload_config> -DTEST_PATH=mount_point_wrong/a)
 set_tests_properties("preload_config_invalid"
 	PROPERTIES PASS_REGULAR_EXPRESSION "EIO")
+
 add_test_generic(config "_invalid_plus_nested" $<TARGET_FILE:preload_config> -DTEST_PATH=mount_point_wrong/a/b/c)
 set_tests_properties("preload_config_invalid_plus_nested"
 	PROPERTIES PASS_REGULAR_EXPRESSION "EIO")
+
 add_test_generic(config "_valid_plus_nested" $<TARGET_FILE:preload_config> -DTEST_PATH=mount_point/a/b)
 set_tests_properties("preload_config_valid_plus_nested"
 	PROPERTIES PASS_REGULAR_EXPRESSION "ENOENT")
+
 add_test_generic(config "_invalid_via_valid" $<TARGET_FILE:preload_config> -DTEST_PATH=mount_point/./../mount_point_wrong/a)
 set_tests_properties("preload_config_invalid_via_valid"
 	PROPERTIES PASS_REGULAR_EXPRESSION "EIO")
+
 add_test_generic(config "_outer_via_valid" $<TARGET_FILE:preload_config> -DTEST_PATH=mount_point/../a)
 set_tests_properties("preload_config_outer_via_valid"
 	PROPERTIES PASS_REGULAR_EXPRESSION "no error")
+
 add_test_generic(config "_outer_via_invalid" $<TARGET_FILE:preload_config> -DTEST_PATH=mount_point_wrong/../a)
 set_tests_properties("preload_config_outer_via_invalid"
 	PROPERTIES PASS_REGULAR_EXPRESSION "EIO")
+
+add_test_generic(xattr "" $<TARGET_FILE:preload_xattr>)

--- a/tests/preload/unix/unix.c
+++ b/tests/preload/unix/unix.c
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * unix.c - validate that unix sockets functions work for paths outside of
+ * pmemfile pool when path crosses mount point
+ */
+
+#define _GNU_SOURCE
+
+#include <err.h>
+#include <limits.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+int
+main(int argc, char *argv[])
+{
+	if (argc < 2)
+		return -1;
+
+	const char *add = "/mount_point/../file";
+	struct sockaddr_un sockaddr;
+	struct stat statbuf;
+
+	if (strlen(argv[1]) >= sizeof(sockaddr.sun_path) - strlen(add))
+		err(1, "too long path (%zd >= %zd)", strlen(argv[1]),
+				sizeof(sockaddr.sun_path) - strlen(add));
+
+	/* test non-pmemfile path */
+	int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (fd < 0)
+		err(2, "socket failed");
+
+	sockaddr.sun_family = AF_UNIX;
+	sprintf(sockaddr.sun_path, "%s/file", argv[1]);
+
+	if (stat(sockaddr.sun_path, &statbuf) == 0)
+		err(3, "file already exists");
+
+	if (bind(fd, &sockaddr, sizeof(sockaddr)))
+		err(4, "bind failed");
+
+	close(fd);
+
+	if (stat(sockaddr.sun_path, &statbuf) != 0)
+		err(5, "file doesn't exist");
+
+	if (unlink(sockaddr.sun_path))
+		err(6, "unlink failed");
+
+	if (stat(sockaddr.sun_path, &statbuf) == 0)
+		err(7, "file still exists");
+
+	/* and now exercise pmemfile path */
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (fd < 0)
+		err(8, "socket failed");
+
+	sprintf(sockaddr.sun_path, "%s%s", argv[1], add);
+
+	if (bind(fd, &sockaddr, sizeof(sockaddr)))
+		err(9, "bind failed");
+
+	close(fd);
+
+	if (stat(sockaddr.sun_path, &statbuf) != 0)
+		err(10, "file doesn't exist");
+
+	if (unlink(sockaddr.sun_path))
+		err(11, "unlink failed");
+
+	if (stat(sockaddr.sun_path, &statbuf) == 0)
+		err(12, "file still exists");
+
+	return 0;
+}

--- a/tests/preload/unix/unix.cmake
+++ b/tests/preload/unix/unix.cmake
@@ -1,0 +1,49 @@
+#
+# Copyright 2017, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+include(${SRC_DIR}/../preload-helpers.cmake)
+
+setup()
+
+mkfs(${DIR}/fs 16m)
+
+execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${DIR}/mount_point)
+
+set(ENV{LD_PRELOAD} ${PRELOAD_LIB})
+set(ENV{PMEMFILE_POOLS} ${DIR}/mount_point:${DIR}/fs)
+set(ENV{PMEMFILE_PRELOAD_LOG} ${BIN_DIR}/pmemfile_preload.log)
+set(ENV{INTERCEPT_LOG} ${BIN_DIR}/intercept.log)
+
+execute(${MAIN_EXECUTABLE} ${DIR})
+
+unset(ENV{LD_PRELOAD})
+
+cleanup()

--- a/tests/preload/xattr/xattr.c
+++ b/tests/preload/xattr/xattr.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * xattr.c - validate that *xattr functions work for paths outside of pmemfile
+ * pool where path crosses mount point
+ */
+
+#define _GNU_SOURCE
+
+#include <err.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+/* This header file is buggy and does not include its dependencies */
+#include <attr/xattr.h>
+
+int
+main(int argc, char *argv[])
+{
+	if (argc < 2)
+		return -1;
+
+	char path[PATH_MAX];
+	sprintf(path, "%s/file", argv[1]);
+	int fd = open(path, O_CREAT | O_EXCL | O_WRONLY, 0644);
+	if (fd < 0)
+		err(1, "open %s", path);
+
+	close(fd);
+
+	char value[1024];
+	ssize_t size = getxattr(path, "user.attr1", value, sizeof(value));
+	if (size != -1)
+		err(2, "attr1 already exists");
+
+	const char *lorem =
+		"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+	size_t lorem_len = strlen(lorem);
+
+	if (setxattr(path, "user.attr1", lorem, lorem_len, XATTR_CREATE) != 0)
+		err(3, "setxattr failed");
+
+	size = getxattr(path, "user.attr1", value, sizeof(value));
+	if (size < 0)
+		err(4, "attr1 is empty");
+	if ((size_t)size != lorem_len)
+		errx(5, "attr1 has unexpected value %ld", size);
+
+	if (strcmp(lorem, value) != 0)
+		err(6, "unexpected attr1 value: %s", value);
+
+	sprintf(path, "%s/mount_point/../file", argv[1]);
+
+	memset(value, 0, sizeof(value));
+	size = getxattr(path, "user.attr1", value, sizeof(value));
+	if (size < 0)
+		err(7, "attr1 is empty (2)");
+	if ((size_t)size != lorem_len)
+		errx(8, "attr1 has unexpected value %ld (2)", size);
+
+	if (strcmp(lorem, value) != 0)
+		err(9, "unexpected attr1 value: %s", value);
+
+	if (setxattr(path, "user.attr1", "meh", 3, XATTR_REPLACE) != 0)
+		err(10, "setxattr failed (2)");
+
+	memset(value, 0, sizeof(value));
+	size = getxattr(path, "user.attr1", value, sizeof(value));
+	if (size < 0)
+		err(11, "attr1 is empty (3)");
+	if ((size_t)size != 3)
+		errx(12, "attr1 has unexpected value %ld (3)", size);
+
+	if (strcmp("meh", value) != 0)
+		err(13, "unexpected attr1 value: %s (2)", value);
+
+	return 0;
+}

--- a/tests/preload/xattr/xattr.c
+++ b/tests/preload/xattr/xattr.c
@@ -109,5 +109,15 @@ main(int argc, char *argv[])
 	if (strcmp("meh", value) != 0)
 		err(13, "unexpected attr1 value: %s (2)", value);
 
+	memset(value, 0, sizeof(value));
+	size = listxattr(path, value, sizeof(value));
+	if (size < 0)
+		err(14, "listxattr failed");
+	if (size != 11)
+		errx(15, "listxattr returned unexpected value: %ld", size);
+
+	if (lremovexattr(path, "user.attr1"))
+		err(16, "lremovexattr failed");
+
 	return 0;
 }

--- a/tests/preload/xattr/xattr.cmake
+++ b/tests/preload/xattr/xattr.cmake
@@ -1,0 +1,49 @@
+#
+# Copyright 2017, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+include(${SRC_DIR}/../preload-helpers.cmake)
+
+setup()
+
+mkfs(${DIR}/fs 16m)
+
+execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${DIR}/mount_point)
+
+set(ENV{LD_PRELOAD} ${PRELOAD_LIB})
+set(ENV{PMEMFILE_POOLS} ${DIR}/mount_point:${DIR}/fs)
+set(ENV{PMEMFILE_PRELOAD_LOG} ${BIN_DIR}/pmemfile_preload.log)
+set(ENV{INTERCEPT_LOG} ${BIN_DIR}/intercept.log)
+
+execute(${MAIN_EXECUTABLE} ${DIR})
+
+unset(ENV{LD_PRELOAD})
+
+cleanup()

--- a/utils/docker/images/Dockerfile.fedora-23
+++ b/utils/docker/images/Dockerfile.fedora-23
@@ -48,6 +48,7 @@ RUN dnf install -y \
 	doxygen \
 	gcc \
 	git \
+	libattr-devel \
 	libcap-devel \
 	libunwind-devel \
 	make \

--- a/utils/docker/images/Dockerfile.fedora-24
+++ b/utils/docker/images/Dockerfile.fedora-24
@@ -48,6 +48,7 @@ RUN dnf install -y \
 	doxygen \
 	gcc \
 	git \
+	libattr-devel \
 	libcap-devel \
 	libunwind-devel \
 	make \

--- a/utils/docker/images/Dockerfile.fedora-25
+++ b/utils/docker/images/Dockerfile.fedora-25
@@ -48,6 +48,7 @@ RUN dnf install -y \
 	doxygen \
 	gcc \
 	git \
+	libattr-devel \
 	libcap-devel \
 	libunwind-devel \
 	make \

--- a/utils/docker/images/Dockerfile.ubuntu-15.10
+++ b/utils/docker/images/Dockerfile.ubuntu-15.10
@@ -50,6 +50,7 @@ RUN apt-get install -y \
 	devscripts \
 	doxygen \
 	git \
+	libattr1-dev \
 	libcap-dev \
 	libcapstone-dev \
 	libc6-dbg \

--- a/utils/docker/images/Dockerfile.ubuntu-16.04
+++ b/utils/docker/images/Dockerfile.ubuntu-16.04
@@ -51,6 +51,7 @@ RUN apt-get install -y \
 	devscripts \
 	doxygen \
 	git \
+	libattr1-dev \
 	libcapstone-dev \
 	libcap-dev \
 	libc6-dbg \

--- a/utils/docker/images/Dockerfile.ubuntu-16.10
+++ b/utils/docker/images/Dockerfile.ubuntu-16.10
@@ -50,6 +50,7 @@ RUN apt-get install -y \
 	devscripts \
 	doxygen \
 	git \
+	libattr1-dev \
 	libcapstone-dev \
 	libcap-dev \
 	libc6-dbg \

--- a/utils/docker/images/Dockerfile.ubuntu-17.04
+++ b/utils/docker/images/Dockerfile.ubuntu-17.04
@@ -50,6 +50,7 @@ RUN apt-get install -y \
 	devscripts \
 	doxygen \
 	git \
+	libattr1-dev \
 	libcapstone-dev \
 	libcap-dev \
 	libc6-dbg \


### PR DESCRIPTION
Bind (for unix sockets) was not handled at all. For getxattr, setxattr, listxattr, llistxattr, removexattr, lremovexattr and chroot paths that pointed outside of pmemfile pool but crossed pmemfile mount point (/mnt/pmemfile/../../tmp/file) were handled incorrectly.

Fixes #181.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/238)
<!-- Reviewable:end -->
