### PR TITLE
posix: add ENOSPC errno for pmemfile_write

### DIFF
--- a/src/libpmemfile-posix/write.c
+++ b/src/libpmemfile-posix/write.c
@@ -194,6 +194,8 @@ pmemfile_pwritev_internal(PMEMfilepool *pfp,
 			TX_SET_DIRECT(inode, mtime, tm);
 		}
 	} TX_ONABORT {
+		if (errno == ENOMEM)
+			errno = ENOSPC;
 		error = errno;
 		vinode_restore_on_abort(vinode);
 	} TX_END

--- a/tests/posix/rw/rw.cpp
+++ b/tests/posix/rw/rw.cpp
@@ -1368,6 +1368,7 @@ TEST_F(rw, failed_write)
 	 * is larger than the pool size.
 	 */
 	ASSERT_EQ(pmemfile_write(pfp, f, buf, 1024 * 1024 * 1024), -1);
+	EXPECT_EQ(errno, ENOSPC);
 
 	ASSERT_EQ(test_pmemfile_path_size(pfp, "/file1"), 5);
 


### PR DESCRIPTION
When pmemfile_write fails, with no space left, it sets errno to ENOMEM. This is errno returned from libpmemobj.

However when POSIX write fails it will set errno to ENOSPC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/240)
<!-- Reviewable:end -->
