### PR TITLE
posix: negative offset for lseek is an error

### DIFF
--- a/src/libpmemfile-posix/lseek.c
+++ b/src/libpmemfile-posix/lseek.c
@@ -126,17 +126,22 @@ lseek_seek_data_or_hole(PMEMfilepool *pfp, struct pmemfile_vinode *vinode,
 	if (!vinode_is_regular_file(vinode))
 		return -EBADF; /* XXX directories are not supported here yet */
 
-	if (offset > fsize) {
+	if (offset < 0 || offset > fsize) {
 		/*
+		 * offset < 0
+		 * on xfs calling lseek data or hole with negative offset
+		 * will return -1 with ENXIO errno
+		 * this also happens with proper ext4 implementation
+		 * (Linux 4.4.76 is fine, however Linux 4.9.37 has
+		 * a bug which causes EFSCORRUPTED errno)
+		 *
+		 * offset > fsize
 		 * From GNU man page: ENXIO if
 		 * "...ENXIO  whence is SEEK_DATA or SEEK_HOLE, and the file
 		 * offset is beyond the end of the file..."
 		 */
 		return -ENXIO;
 	}
-
-	if (offset < 0) /* this seems to be allowed by POSIX and Linux */
-		offset = 0;
 
 	if (whence == PMEMFILE_SEEK_DATA) {
 		offset = lseek_seek_data(pfp, vinode, offset, fsize);

--- a/tests/posix/rw/rw.cpp
+++ b/tests/posix/rw/rw.cpp
@@ -1108,7 +1108,14 @@ TEST_F(rw, sparse_files_using_lseek)
 
 	ASSERT_EQ(pmemfile_lseek(pfp, f, 0, PMEMFILE_SEEK_HOLE), 0);
 	ASSERT_EQ(pmemfile_lseek(pfp, f, 0, PMEMFILE_SEEK_DATA), 0);
-	ASSERT_EQ(pmemfile_lseek(pfp, f, -1, PMEMFILE_SEEK_DATA), 0);
+
+	/* Seeking to data, or to hole should fail with negative offset */
+	errno = 0;
+	ASSERT_EQ(pmemfile_lseek(pfp, f, -1, PMEMFILE_SEEK_DATA), -1);
+	ASSERT_EQ(errno, ENXIO);
+	errno = 0;
+	ASSERT_EQ(pmemfile_lseek(pfp, f, -1, PMEMFILE_SEEK_HOLE), -1);
+	ASSERT_EQ(errno, ENXIO);
 
 	/*
 	 * Seeking to hole, or to data should fail with offset


### PR DESCRIPTION
Calling lseek data or hole with negative offset should return -1 with ENXIO errno.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/256)
<!-- Reviewable:end -->
