### PR TITLE
posix: fix errno for lseek to data/hole on directory

### DIFF
--- a/src/libpmemfile-posix/lseek.c
+++ b/src/libpmemfile-posix/lseek.c
@@ -124,7 +124,7 @@ lseek_seek_data_or_hole(PMEMfilepool *pfp, struct pmemfile_vinode *vinode,
 	pmemfile_ssize_t fsize = (pmemfile_ssize_t)vinode->inode->size;
 
 	if (!vinode_is_regular_file(vinode))
-		return -EBADF; /* XXX directories are not supported here yet */
+		return -ENXIO;
 
 	if (offset < 0 || offset > fsize) {
 		/*

--- a/tests/posix/rw/rw.cpp
+++ b/tests/posix/rw/rw.cpp
@@ -1091,13 +1091,13 @@ TEST_F(rw, sparse_files_using_lseek)
 	f = pmemfile_open(pfp, "/", PMEMFILE_O_DIRECTORY);
 	ASSERT_NE(f, nullptr) << strerror(errno);
 
-	/* Using these two flags with direcotries is not supported (yet?) */
+	/* Using these two flags with directories is not supported */
 	errno = 0;
 	ASSERT_EQ(pmemfile_lseek(pfp, f, 1, PMEMFILE_SEEK_HOLE), -1);
-	ASSERT_EQ(errno, EBADF);
+	ASSERT_EQ(errno, ENXIO);
 	errno = 0;
 	ASSERT_EQ(pmemfile_lseek(pfp, f, 1, PMEMFILE_SEEK_DATA), -1);
-	ASSERT_EQ(errno, EBADF);
+	ASSERT_EQ(errno, ENXIO);
 
 	pmemfile_close(pfp, f);
 


### PR DESCRIPTION
btrfs and xfs return -1 with ENXIO errno when calling lseek to data/hole on directory

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/258)
<!-- Reviewable:end -->
