### PR TITLE
posix: fix errno for lseek to CUR and END

### DIFF
--- a/src/libpmemfile-posix/lseek.c
+++ b/src/libpmemfile-posix/lseek.c
@@ -195,6 +195,19 @@ pmemfile_lseek_locked(PMEMfilepool *pfp, PMEMfile *file, pmemfile_off_t offset,
 				 * From POSIX: EINVAL if
 				 * "...the resulting file offset would be
 				 * negative for a regular file..."
+				 *
+				 * POSIX manpage also mentions EOVERFLOW
+				 * "The resulting file offset would be a value
+				 * which cannot be represented correctly in an
+				 * object of type off_t."
+				 * However in existing implementations it looks
+				 * like it is only used to represent user-type
+				 * overflow - user calls lseek, when off_t is
+				 * 32-bit, but internal kernel type is 64-bit,
+				 * and returned value cannot be represented
+				 * EOVERFLOW is returned.
+				 * With 64-bit off_t type EINVAL is returned in
+				 * case of overflow.
 				 */
 				new_errno = EINVAL;
 			}
@@ -202,18 +215,8 @@ pmemfile_lseek_locked(PMEMfilepool *pfp, PMEMfile *file, pmemfile_off_t offset,
 		case PMEMFILE_SEEK_CUR:
 			ret = (pmemfile_off_t)file->offset + offset;
 			if (ret < 0) {
-				if (offset < 0) {
-					new_errno = EINVAL;
-				} else {
-					/*
-					 * From POSIX: EOVERFLOW if
-					 * "...The resulting file offset would
-					 * be a value which cannot be
-					 * represented correctly in an object
-					 * of type off_t..."
-					 */
-					new_errno = EOVERFLOW;
-				}
+				/* Error as in SEEK_SET */
+				new_errno = EINVAL;
 			}
 			break;
 		case PMEMFILE_SEEK_END:
@@ -221,11 +224,8 @@ pmemfile_lseek_locked(PMEMfilepool *pfp, PMEMfile *file, pmemfile_off_t offset,
 			ret = (pmemfile_off_t)inode->size + offset;
 			os_rwlock_unlock(&vinode->rwlock);
 			if (ret < 0) {
-				/* Errors as in SEEK_CUR */
-				if (offset < 0)
-					new_errno = EINVAL;
-				else
-					new_errno = EOVERFLOW;
+				/* Error as in SEEK_SET */
+				new_errno = EINVAL;
 			}
 			break;
 		case PMEMFILE_SEEK_DATA:

--- a/tests/posix/rw/rw.cpp
+++ b/tests/posix/rw/rw.cpp
@@ -237,13 +237,13 @@ TEST_F(rw, basic)
 	ASSERT_EQ(errno, EINVAL);
 	errno = 0;
 	ASSERT_EQ(pmemfile_lseek(pfp, f, INT64_MAX, PMEMFILE_SEEK_CUR), -1);
-	ASSERT_EQ(errno, EOVERFLOW);
+	ASSERT_EQ(errno, EINVAL);
 	errno = 0;
 	ASSERT_EQ(pmemfile_lseek(pfp, f, INT64_MAX - 1, PMEMFILE_SEEK_CUR), -1);
-	ASSERT_EQ(errno, EOVERFLOW);
+	ASSERT_EQ(errno, EINVAL);
 	errno = 0;
 	ASSERT_EQ(pmemfile_lseek(pfp, f, INT64_MAX - 1, PMEMFILE_SEEK_END), -1);
-	ASSERT_EQ(errno, EOVERFLOW);
+	ASSERT_EQ(errno, EINVAL);
 	errno = 0;
 	ASSERT_EQ(pmemfile_lseek(pfp, f, INT64_MIN, PMEMFILE_SEEK_END), -1);
 	ASSERT_EQ(errno, EINVAL);


### PR DESCRIPTION
EOVERFLOW errno is only relevant with 32-bit off_t

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/262)
<!-- Reviewable:end -->
