### PR TITLE
posix: fix lseek to end on directory

### DIFF
--- a/tests/posix/getdents/getdents.cpp
+++ b/tests/posix/getdents/getdents.cpp
@@ -148,9 +148,10 @@ TEST_F(getdents, 1)
 				    PMEMFILE_O_DIRECTORY | PMEMFILE_O_RDONLY);
 	ASSERT_NE(f, nullptr) << strerror(errno);
 
-	errno = 0;
-	ASSERT_EQ(pmemfile_lseek(pfp, f, 0, PMEMFILE_SEEK_END), -1);
-	EXPECT_EQ(errno, EINVAL);
+	/* 4 entries in directory and '.' '..' */
+	ASSERT_EQ(pmemfile_lseek(pfp, f, 0, PMEMFILE_SEEK_END), 6);
+
+	ASSERT_EQ(pmemfile_lseek(pfp, f, 0, PMEMFILE_SEEK_SET), 0);
 
 	char buf[32758];
 	struct linux_dirent *dirents = (struct linux_dirent *)buf;


### PR DESCRIPTION
Implemented lseek seek to end on directory.
It works similar to ext4 - returned value if offset which last directory entry points at.

However in ext4 it is always INT64_MAX - last and empty entry always equals INT64_MAX.
In libpmemfile-posix it is more complicated since last entry does not point at INT64_MAX.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/275)
<!-- Reviewable:end -->
