### PR TITLE
Process switching, pmemfile-mount, pmemfile_pool_set_device & some fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,18 @@ We reserve the right to change the on-media layout without warning.
 # Example: #
 
 ```sh
-$ mkfs.pmemfile /mnt/pmem/pmemfile_pool 1G
+$ mkfs.pmemfile /dev/dax0.0 0
 $ mkdir /tmp/mountpoint
-$ alias pf='LD_PRELOAD=libpmemfile.so PMEMFILE_POOLS=/tmp/mountpoint:/mnt/pmem/pmemfile_pool'
+
+$ sudo pmemfile-mount /dev/dax0.0 /tmp/mountpoint
+$ alias pf='LD_PRELOAD=libpmemfile.so'
+
+# or if you don't have root access:
+
+$ alias pf='LD_PRELOAD=libpmemfile.so PMEMFILE_POOLS=/tmp/mountpoint:/dev/dax0.0'
+
 # now all commands prefixed with 'pf' will see files under /tmp/mountpoint,
-# but files will be stored in file system backed by /mnt/pmem/pmemfile_pool
+# but files will be stored in file system backed by /dev/dax0.0
 $ pf mkdir /tmp/mountpoint/dir_in_pmemfile
 $ pf cp README.md /tmp/mountpoint/dir_in_pmemfile
 $ pf ls -l /tmp/mountpoint/

--- a/debian/pmemfile-tools.install
+++ b/debian/pmemfile-tools.install
@@ -1,2 +1,3 @@
 usr/bin/mkfs.pmemfile
+usr/bin/pmemfile-mount
 usr/share/man/man1/mkfs.pmemfile.1

--- a/include/libpmemfile-posix.h
+++ b/include/libpmemfile-posix.h
@@ -383,6 +383,9 @@ PMEMfile *pmemfile_open_parent(PMEMfilepool *pfp, PMEMfile *at,
 
 const char *pmemfile_errormsg(void);
 
+int pmemfile_pool_resume(PMEMfilepool *pfp, const char *pathname);
+int pmemfile_pool_suspend(PMEMfilepool *pfp);
+
 #include "libpmemfile-posix-stubs.h"
 
 #ifdef FAULT_INJECTION

--- a/include/libpmemfile-posix.h
+++ b/include/libpmemfile-posix.h
@@ -208,6 +208,7 @@ PMEMfilepool *pmemfile_pool_create(const char *pathname, size_t poolsize,
 
 PMEMfilepool *pmemfile_pool_open(const char *pathname);
 void pmemfile_pool_close(PMEMfilepool *pfp);
+void pmemfile_pool_set_device(PMEMfilepool *pfp, pmemfile_dev_t dev);
 
 PMEMfile *pmemfile_open(PMEMfilepool *pfp, const char *pathname, int flags,
 		...);

--- a/pmemfile.spec
+++ b/pmemfile.spec
@@ -71,6 +71,7 @@ XXX
 %files -n pmemfile-tools
 %defattr(-,root,root,-)
 %{_bindir}/mkfs.pmemfile
+%{_bindir}/pmemfile-mount
 %{_mandir}/man1/mkfs.pmemfile.1.gz
 %license LICENSE
 %doc

--- a/src/libpmemfile-posix/CMakeLists.txt
+++ b/src/libpmemfile-posix/CMakeLists.txt
@@ -151,6 +151,7 @@ set(EXPORTED_SYMBOLS
 	pmemfile_pool_create
 	pmemfile_pool_open
 	pmemfile_pool_resume
+	pmemfile_pool_set_device
 	pmemfile_pool_suspend
 	pmemfile_posix_fallocate
 	pmemfile_pread

--- a/src/libpmemfile-posix/CMakeLists.txt
+++ b/src/libpmemfile-posix/CMakeLists.txt
@@ -150,6 +150,8 @@ set(EXPORTED_SYMBOLS
 	pmemfile_pool_close
 	pmemfile_pool_create
 	pmemfile_pool_open
+	pmemfile_pool_resume
+	pmemfile_pool_suspend
 	pmemfile_posix_fallocate
 	pmemfile_pread
 	pmemfile_preadv

--- a/src/libpmemfile-posix/hash_map.c
+++ b/src/libpmemfile-posix/hash_map.c
@@ -109,7 +109,7 @@ hash_map_alloc(void)
  * hash_map_traverse -- returns number of live entries
  */
 int
-hash_map_traverse(struct hash_map *map, hash_map_cb fun)
+hash_map_traverse(struct hash_map *map, hash_map_cb fun, void *arg)
 {
 	int num = 0;
 
@@ -119,7 +119,7 @@ hash_map_traverse(struct hash_map *map, hash_map_cb fun)
 		for (unsigned j = 0; j < BUCKET_SIZE; ++j) {
 			void *value = bucket->arr[j].value;
 			if (value) {
-				fun(bucket->arr[j].key, value);
+				fun(bucket->arr[j].key, value, arg);
 				num++;
 			}
 		}

--- a/src/libpmemfile-posix/hash_map.h
+++ b/src/libpmemfile-posix/hash_map.h
@@ -35,12 +35,12 @@
 #include <stdint.h>
 
 struct hash_map;
-typedef void (*hash_map_cb)(uint64_t, void *);
+typedef void (*hash_map_cb)(uint64_t, void *, void *);
 
 struct hash_map *hash_map_alloc(void);
 void hash_map_free(struct hash_map *map);
 
-int hash_map_traverse(struct hash_map *c, hash_map_cb fun);
+int hash_map_traverse(struct hash_map *c, hash_map_cb fun, void *arg);
 
 int hash_map_remove(struct hash_map *map, uint64_t key, void *value);
 

--- a/src/libpmemfile-posix/inode.c
+++ b/src/libpmemfile-posix/inode.c
@@ -708,7 +708,8 @@ vinode_suspend(PMEMfilepool *pfp, struct pmemfile_vinode *vinode)
 	vinode->inode->suspended_references++;
 
 	_inode_array_add(pfp, pfp->super->suspended_inodes, vinode->tinode,
-			&vinode->suspended.arr, &vinode->suspended.idx, false);
+			&vinode->suspended.arr, &vinode->suspended.idx,
+			INODE_ARRAY_NOLOCK);
 
 	if (vinode->blocks) {
 		ctree_delete(vinode->blocks);
@@ -751,7 +752,8 @@ inode_resume(PMEMfilepool *pfp, struct pmemfile_vinode *vinode,
 	TX_ADD_DIRECT(&inode->suspended_references);
 	inode->suspended_references--;
 
-	_inode_array_unregister(pfp, suspended.arr, suspended.idx, false);
+	_inode_array_unregister(pfp, suspended.arr, suspended.idx,
+			INODE_ARRAY_NOLOCK);
 }
 
 /*

--- a/src/libpmemfile-posix/inode.c
+++ b/src/libpmemfile-posix/inode.c
@@ -51,8 +51,9 @@
 #include "utils.h"
 
 static void
-log_leak(uint64_t key, void *value)
+log_leak(uint64_t key, void *value, void *arg)
 {
+	(void) arg;
 #ifdef DEBUG
 	(void) key;
 	struct pmemfile_vinode *vinode = value;
@@ -71,7 +72,7 @@ void
 inode_map_free(PMEMfilepool *pfp)
 {
 	struct hash_map *map = pfp->inode_map;
-	int ref_leaks = hash_map_traverse(map, log_leak);
+	int ref_leaks = hash_map_traverse(map, log_leak, NULL);
 	if (ref_leaks)
 		FATAL("%d inode reference leaks", ref_leaks);
 

--- a/src/libpmemfile-posix/inode.c
+++ b/src/libpmemfile-posix/inode.c
@@ -218,7 +218,8 @@ vinode_unref(PMEMfilepool *pfp, struct pmemfile_vinode *vinode)
 
 		if (__sync_sub_and_fetch(&vinode->ref, 1) == 0) {
 			uint64_t nlink = vinode->inode->nlink;
-			if (nlink == 0)
+			if (vinode->inode->suspended_references == 0 &&
+					nlink == 0)
 				vinode_free_pmem(pfp, vinode);
 
 			to_unregister = vinode;
@@ -330,6 +331,9 @@ vinode_orphan_unlocked(PMEMfilepool *pfp, struct pmemfile_vinode *vinode)
 
 	ASSERT_IN_TX();
 	ASSERTeq(vinode->orphaned.arr, NULL);
+
+	if (vinode->inode->suspended_references > 0)
+		return;
 
 	TOID(struct pmemfile_inode_array) orphaned =
 			pfp->super->orphaned_inodes;
@@ -692,4 +696,81 @@ vinode_rdlock_with_block_tree(PMEMfilepool *pfp, struct pmemfile_vinode *vinode)
 	}
 
 	return 0;
+}
+
+/*
+ * vinode_suspend -- prepares vinode for pool suspend
+ */
+void
+vinode_suspend(PMEMfilepool *pfp, struct pmemfile_vinode *vinode)
+{
+	TX_ADD_DIRECT(&vinode->inode->suspended_references);
+	vinode->inode->suspended_references++;
+
+	_inode_array_add(pfp, pfp->super->suspended_inodes, vinode->tinode,
+			&vinode->suspended.arr, &vinode->suspended.idx, false);
+
+	if (vinode->blocks) {
+		ctree_delete(vinode->blocks);
+		vinode->blocks = NULL;
+	}
+
+	vinode->first_free_block.arr = NULL;
+	vinode->first_free_block.idx = 0;
+
+	vinode->first_block = NULL;
+}
+
+static inline void *
+add_off(void *ptr, uintptr_t off)
+{
+	return (void *)((uintptr_t)ptr + off);
+}
+
+/*
+ * inode_resume -- restores persistent part of inode after suspend
+ */
+void
+inode_resume(PMEMfilepool *pfp, struct pmemfile_vinode *vinode,
+		PMEMobjpool *old_pop)
+{
+	struct inode_suspend_info suspended = vinode->suspended;
+	struct pmemfile_inode *inode = vinode->inode;
+
+	ASSERT(vinode->suspended.arr != NULL);
+
+	if (pfp->pop != old_pop) {
+		uintptr_t diff = (uintptr_t)pfp->pop - (uintptr_t)old_pop;
+
+		suspended.arr = add_off(suspended.arr, diff);
+		inode = add_off(inode, diff);
+	}
+
+	ASSERT(inode->suspended_references > 0);
+
+	TX_ADD_DIRECT(&inode->suspended_references);
+	inode->suspended_references--;
+
+	_inode_array_unregister(pfp, suspended.arr, suspended.idx, false);
+}
+
+/*
+ * vinode_resume -- restores runtime part of inode after suspend
+ */
+void
+vinode_resume(PMEMfilepool *pfp, struct pmemfile_vinode *vinode,
+		PMEMobjpool *old_pop)
+{
+	vinode->suspended.arr = NULL;
+	vinode->suspended.idx = 0;
+
+	if (pfp->pop != old_pop) {
+		uintptr_t diff = (uintptr_t)pfp->pop - (uintptr_t)old_pop;
+
+		vinode->inode = add_off(vinode->inode, diff);
+
+		if (vinode->orphaned.arr)
+			vinode->orphaned.arr =
+					add_off(vinode->orphaned.arr, diff);
+	}
 }

--- a/src/libpmemfile-posix/inode.h
+++ b/src/libpmemfile-posix/inode.h
@@ -77,6 +77,12 @@ struct pmemfile_vinode {
 		uint32_t idx;
 	} first_free_block;
 
+	/* pointer to the array of suspended inodes */
+	struct inode_suspend_info {
+		struct pmemfile_inode_array *arr;
+		unsigned idx;
+	} suspended;
+
 	/* first used block */
 	struct pmemfile_block_desc *first_block;
 
@@ -168,5 +174,11 @@ blockp_as_oid(struct pmemfile_block_desc *block)
 }
 
 int vinode_rdlock_with_block_tree(PMEMfilepool *, struct pmemfile_vinode *);
+
+void vinode_suspend(PMEMfilepool *pfp, struct pmemfile_vinode *vinode);
+void inode_resume(PMEMfilepool *pfp, struct pmemfile_vinode *vinode,
+		PMEMobjpool *old_pop);
+void vinode_resume(PMEMfilepool *pfp, struct pmemfile_vinode *vinode,
+		PMEMobjpool *old_pop);
 
 #endif

--- a/src/libpmemfile-posix/inode_array.c
+++ b/src/libpmemfile-posix/inode_array.c
@@ -76,6 +76,53 @@ inode_array_add_single(struct pmemfile_inode_array *cur,
 	return false;
 }
 
+void
+_inode_array_add(PMEMfilepool *pfp,
+		TOID(struct pmemfile_inode_array) array,
+		TOID(struct pmemfile_inode) tinode,
+		struct pmemfile_inode_array **ins,
+		unsigned *ins_idx,
+		bool lock)
+{
+	bool found = false;
+	ASSERT_IN_TX();
+
+	do {
+		struct pmemfile_inode_array *cur = PF_RW(pfp, array);
+
+		if (lock)
+			pmemobj_mutex_lock_nofail(pfp->pop, &cur->mtx);
+
+		if (cur->used < NUMINODES_PER_ENTRY)
+			found = inode_array_add_single(cur, tinode, ins,
+					ins_idx);
+
+		bool modified = false;
+		if (!found) {
+			if (TOID_IS_NULL(cur->next)) {
+				mutex_tx_unlock_on_abort(&cur->mtx);
+
+				TX_SET_DIRECT(cur, next,
+					TX_ZNEW(struct pmemfile_inode_array));
+				PF_RW(pfp, cur->next)->prev = array;
+
+				modified = true;
+			}
+
+			array = cur->next;
+		}
+
+		if (lock) {
+			if (found || modified)
+				mutex_tx_unlock_on_commit(&cur->mtx);
+			else
+				pmemobj_mutex_unlock_nofail(pfp->pop,
+						&cur->mtx);
+		}
+
+	} while (!found);
+}
+
 /*
  * inode_array_add -- adds inode to array, returns its position
  *
@@ -88,40 +135,30 @@ inode_array_add(PMEMfilepool *pfp,
 		struct pmemfile_inode_array **ins,
 		unsigned *ins_idx)
 {
-	bool found = false;
+	_inode_array_add(pfp, array, tinode, ins, ins_idx, true);
+}
+
+void
+_inode_array_unregister(PMEMfilepool *pfp,
+		struct pmemfile_inode_array *cur,
+		unsigned idx,
+		bool lock)
+{
 	ASSERT_IN_TX();
 
-	do {
-		struct pmemfile_inode_array *cur = PF_RW(pfp, array);
+	if (lock)
+		mutex_tx_lock(pfp, &cur->mtx);
 
-		pmemobj_mutex_lock_nofail(pfp->pop, &cur->mtx);
+	ASSERT(cur->used > 0);
 
-		if (cur->used < NUMINODES_PER_ENTRY)
-			found = inode_array_add_single(cur, tinode, ins,
-					ins_idx);
+	TX_ADD_DIRECT(&cur->inodes[idx]);
+	cur->inodes[idx] = TOID_NULL(struct pmemfile_inode);
 
-		bool modified = false;
-		if (!found) {
-			if (TOID_IS_NULL(cur->next)) {
-				mutex_tx_unlock_on_abort(
-						&cur->mtx);
+	TX_ADD_DIRECT(&cur->used);
+	cur->used--;
 
-				TX_SET_DIRECT(cur, next,
-					TX_ZNEW(struct pmemfile_inode_array));
-				PF_RW(pfp, cur->next)->prev = array;
-
-				modified = true;
-			}
-
-			array = cur->next;
-		}
-
-		if (found || modified)
-			mutex_tx_unlock_on_commit(&cur->mtx);
-		else
-			pmemobj_mutex_unlock_nofail(pfp->pop, &cur->mtx);
-
-	} while (!found);
+	if (lock)
+		mutex_tx_unlock_on_commit(&cur->mtx);
 }
 
 /*
@@ -135,22 +172,8 @@ inode_array_unregister(PMEMfilepool *pfp,
 		struct pmemfile_inode_array *cur,
 		unsigned idx)
 {
-	ASSERT_IN_TX();
-
-	mutex_tx_lock(pfp, &cur->mtx);
-
-	ASSERT(cur->used > 0);
-
-	TX_ADD_DIRECT(&cur->inodes[idx]);
-	cur->inodes[idx] = TOID_NULL(struct pmemfile_inode);
-
-	TX_ADD_DIRECT(&cur->used);
-	cur->used--;
-
-	mutex_tx_unlock_on_commit(&cur->mtx);
-
+	_inode_array_unregister(pfp, cur, idx, true);
 }
-
 /*
  * inode_array_traverse -- traverses whole inode array and calls specified
  * callback function for each inode

--- a/src/libpmemfile-posix/inode_array.h
+++ b/src/libpmemfile-posix/inode_array.h
@@ -36,11 +36,23 @@
 #include "inode.h"
 #include "layout.h"
 
+
+void _inode_array_add(PMEMfilepool *pfp,
+		TOID(struct pmemfile_inode_array) array,
+		TOID(struct pmemfile_inode) tinode,
+		struct pmemfile_inode_array **ins,
+		unsigned *ins_idx,
+		bool lock);
 void inode_array_add(PMEMfilepool *pfp,
 		TOID(struct pmemfile_inode_array) array,
 		TOID(struct pmemfile_inode) tinode,
 		struct pmemfile_inode_array **ins,
 		unsigned *ins_idx);
+
+void _inode_array_unregister(PMEMfilepool *pfp,
+		struct pmemfile_inode_array *cur,
+		unsigned idx,
+		bool lock);
 void inode_array_unregister(PMEMfilepool *pfp,
 		struct pmemfile_inode_array *cur,
 		unsigned idx);

--- a/src/libpmemfile-posix/inode_array.h
+++ b/src/libpmemfile-posix/inode_array.h
@@ -36,13 +36,14 @@
 #include "inode.h"
 #include "layout.h"
 
+enum inode_array_lock { INODE_ARRAY_LOCK, INODE_ARRAY_NOLOCK };
 
 void _inode_array_add(PMEMfilepool *pfp,
 		TOID(struct pmemfile_inode_array) array,
 		TOID(struct pmemfile_inode) tinode,
 		struct pmemfile_inode_array **ins,
 		unsigned *ins_idx,
-		bool lock);
+		enum inode_array_lock lock);
 void inode_array_add(PMEMfilepool *pfp,
 		TOID(struct pmemfile_inode_array) array,
 		TOID(struct pmemfile_inode) tinode,
@@ -52,7 +53,7 @@ void inode_array_add(PMEMfilepool *pfp,
 void _inode_array_unregister(PMEMfilepool *pfp,
 		struct pmemfile_inode_array *cur,
 		unsigned idx,
-		bool lock);
+		enum inode_array_lock lock);
 void inode_array_unregister(PMEMfilepool *pfp,
 		struct pmemfile_inode_array *cur,
 		unsigned idx);

--- a/src/libpmemfile-posix/layout.h
+++ b/src/libpmemfile-posix/layout.h
@@ -151,8 +151,11 @@ struct pmemfile_inode {
 	/* group */
 	uint32_t gid;
 
-	/* unused / padding */
-	uint32_t reserved;
+	/*
+	 * Number of references from processes that called
+	 * pmemfile_pool_suspend.
+	 */
+	uint32_t suspended_references;
 
 	/* time of last access */
 	struct pmemfile_time atime;
@@ -232,8 +235,12 @@ struct pmemfile_super {
 	/* list of arrays of inodes that were deleted, but are still opened */
 	TOID(struct pmemfile_inode_array) orphaned_inodes;
 
+	/* list of arrays of inodes that are suspended */
+	TOID(struct pmemfile_inode_array) suspended_inodes;
+
 	char padding[PMEMFILE_SUPER_SIZE
 			- 8  /* version */
+			- 16 /* toid */
 			- 16 /* toid */
 			- 16 /* toid */];
 };

--- a/src/libpmemfile-posix/os_util.h
+++ b/src/libpmemfile-posix/os_util.h
@@ -47,4 +47,6 @@ const char *os_getexecname(void);
 
 #endif	/* DEBUG */
 
+int os_usleep(unsigned usec);
+
 #endif

--- a/src/libpmemfile-posix/os_util_linux.c
+++ b/src/libpmemfile-posix/os_util_linux.c
@@ -76,3 +76,9 @@ os_getexecname(void)
 	return namepath;
 }
 #endif	/* DEBUG */
+
+int
+os_usleep(unsigned usec)
+{
+	return usleep(usec);
+}

--- a/src/libpmemfile-posix/pool.c
+++ b/src/libpmemfile-posix/pool.c
@@ -47,6 +47,7 @@
 #include "locks.h"
 #include "mkdir.h"
 #include "os_thread.h"
+#include "os_util.h"
 #include "out.h"
 #include "pool.h"
 #include "utils.h"
@@ -101,6 +102,7 @@ initialize_super_block(PMEMfilepool *pfp)
 
 			super->version = PMEMFILE_CUR_VERSION;
 			super->orphaned_inodes = inode_array_alloc();
+			super->suspended_inodes = inode_array_alloc();
 		} TX_ONABORT {
 			error = errno;
 		} TX_END
@@ -290,4 +292,103 @@ pmemfile_pool_close(PMEMfilepool *pfp)
 	memset(pfp, 0, sizeof(*pfp));
 
 	pf_free(pfp);
+}
+
+struct resume_info {
+	PMEMfilepool *pfp;
+	PMEMobjpool *old_pop;
+};
+
+static void
+vinode_suspend_cb(uint64_t off, void *vinode, void *arg)
+{
+	vinode_suspend(arg, vinode);
+}
+
+static void
+inode_resume_cb(uint64_t off, void *vinode, void *arg)
+{
+	struct resume_info *info = arg;
+	inode_resume(info->pfp, vinode, info->old_pop);
+}
+
+static void
+vinode_resume_cb(uint64_t off, void *vinode, void *arg)
+{
+	struct resume_info *info = arg;
+	vinode_resume(info->pfp, vinode, info->old_pop);
+}
+
+/*
+ * pmemfile_pool_resume -- notifies pmemfile that pool is now going to be used
+ *
+ * Can be called only after pmemfile_pool_suspend.
+ */
+int
+pmemfile_pool_resume(PMEMfilepool *pfp, const char *pathname)
+{
+	PMEMobjpool *new_pop = NULL;
+
+	while (new_pop == NULL) {
+		new_pop = pmemobj_open(pathname, POBJ_LAYOUT_NAME(pmemfile));
+		if (new_pop == NULL)
+			// XXX
+			os_usleep(1000);
+	}
+
+	int error = 0;
+	PMEMobjpool *old_pop = pfp->pop;
+	struct pmemfile_super *old_super = pfp->super;
+
+	if (new_pop != pfp->pop) {
+		pfp->pop = new_pop;
+		pfp->super = pmemobj_direct(pmemobj_root(pfp->pop, 0));
+	}
+	struct resume_info arg = {pfp, old_pop};
+
+	TX_BEGIN_CB(pfp->pop, cb_queue, pfp) {
+		hash_map_traverse(pfp->inode_map, inode_resume_cb, &arg);
+	} TX_ONABORT {
+		error = -1;
+	} TX_END
+
+	if (error) {
+		int oerrno = errno;
+		pmemobj_close(new_pop);
+		errno = oerrno;
+
+		pfp->pop = old_pop;
+		pfp->super = old_super;
+		return -1;
+	}
+
+	hash_map_traverse(pfp->inode_map, vinode_resume_cb, &arg);
+
+	return 0;
+}
+
+/*
+ * pmemfile_pool_suspend -- notifies pmemfile that pool is not going to be used
+ *                          until pmemfile_pool_restore
+ *
+ * This function CAN NOT be called while any pmemfile function (including this
+ * one) is in progress (even for other pools, because of pmemobj_close/open
+ * not being safe)!
+ */
+int
+pmemfile_pool_suspend(PMEMfilepool *pfp)
+{
+	int error = 0;
+
+	TX_BEGIN_CB(pfp->pop, cb_queue, pfp) {
+		hash_map_traverse(pfp->inode_map, vinode_suspend_cb, pfp);
+	} TX_ONABORT {
+		error = -1;
+	} TX_END
+
+	if (error)
+		return -1;
+
+	pmemobj_close(pfp->pop);
+	return 0;
 }

--- a/src/libpmemfile-posix/pool.c
+++ b/src/libpmemfile-posix/pool.c
@@ -128,6 +128,7 @@ initialize_super_block(PMEMfilepool *pfp)
 #endif
 
 	pfp->cwd = vinode_ref(pfp, pfp->root);
+	pfp->dev = pfp->root->tinode.oid.pool_uuid_lo;
 	cred_release(&cred);
 
 	return 0;
@@ -267,6 +268,15 @@ pool_open:
 	pf_free(pfp);
 	errno = error;
 	return NULL;
+}
+
+/*
+ * pmemfile_pool_set_device -- set device id for pool
+ */
+void
+pmemfile_pool_set_device(PMEMfilepool *pfp, pmemfile_dev_t dev)
+{
+	pfp->dev = dev;
 }
 
 /*

--- a/src/libpmemfile-posix/pool.h
+++ b/src/libpmemfile-posix/pool.h
@@ -47,6 +47,8 @@ struct pmemfilepool {
 	/* pmemobj pool pointer */
 	PMEMobjpool *pop;
 
+	pmemfile_dev_t dev;
+
 	/* root directory */
 	struct pmemfile_vinode *root;
 	mode_t umask;

--- a/src/libpmemfile-posix/stat.c
+++ b/src/libpmemfile-posix/stat.c
@@ -40,6 +40,7 @@
 #include "inode.h"
 #include "libpmemfile-posix.h"
 #include "out.h"
+#include "pool.h"
 #include "utils.h"
 
 /*
@@ -67,7 +68,7 @@ vinode_stat(PMEMfilepool *pfp, struct pmemfile_vinode *vinode,
 		return EFAULT;
 
 	memset(buf, 0, sizeof(*buf));
-	buf->st_dev = vinode->tinode.oid.pool_uuid_lo;
+	buf->st_dev = pfp->dev;
 	buf->st_ino = vinode->tinode.oid.off;
 	buf->st_mode = inode->flags & (PMEMFILE_S_IFMT | PMEMFILE_ALLPERMS);
 	buf->st_nlink = inode->nlink;

--- a/src/libpmemfile/CMakeLists.txt
+++ b/src/libpmemfile/CMakeLists.txt
@@ -69,6 +69,7 @@ add_library(pmemfile_static_unscoped STATIC $<TARGET_OBJECTS:pmemfile_o>)
 target_link_libraries(pmemfile_shared PRIVATE ${SYSCALL_INTERCEPT_LIBRARIES})
 target_link_libraries(pmemfile_shared PRIVATE ${CAP_LIBRARIES})
 target_link_libraries(pmemfile_shared PRIVATE ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(pmemfile_shared PRIVATE ${CMAKE_DL_LIBS})
 target_link_libraries(pmemfile_shared PRIVATE pmemfile-posix_shared)
 target_link_libraries(pmemfile_shared PRIVATE -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libpmemfile.map)
 

--- a/src/libpmemfile/libpmemfile-posix-fd_first.h
+++ b/src/libpmemfile/libpmemfile-posix-fd_first.h
@@ -40,6 +40,7 @@
 static inline void
 fd_first_pmemfile_close(struct fd_association *file)
 {
+	assert(!file->pool->suspended);
 	wrapper_pmemfile_close(file->pool->pool, file->file);
 }
 
@@ -48,6 +49,7 @@ fd_first_pmemfile_read(struct fd_association *file,
 		long buf,
 		long count)
 {
+	assert(!file->pool->suspended);
 	return wrapper_pmemfile_read(file->pool->pool, file->file,
 		(void *)buf,
 		(size_t)count);
@@ -59,6 +61,7 @@ fd_first_pmemfile_pread(struct fd_association *file,
 		long count,
 		long offset)
 {
+	assert(!file->pool->suspended);
 	return wrapper_pmemfile_pread(file->pool->pool, file->file,
 		(void *)buf,
 		(size_t)count,
@@ -70,6 +73,7 @@ fd_first_pmemfile_readv(struct fd_association *file,
 		long iov,
 		long iovcnt)
 {
+	assert(!file->pool->suspended);
 	return wrapper_pmemfile_readv(file->pool->pool, file->file,
 		(const pmemfile_iovec_t *)iov,
 		(int)iovcnt);
@@ -81,6 +85,7 @@ fd_first_pmemfile_preadv(struct fd_association *file,
 		long iovcnt,
 		long offset)
 {
+	assert(!file->pool->suspended);
 	return wrapper_pmemfile_preadv(file->pool->pool, file->file,
 		(const pmemfile_iovec_t *)iov,
 		(int)iovcnt,
@@ -92,6 +97,7 @@ fd_first_pmemfile_write(struct fd_association *file,
 		long buf,
 		long count)
 {
+	assert(!file->pool->suspended);
 	return wrapper_pmemfile_write(file->pool->pool, file->file,
 		(const void *)buf,
 		(size_t)count);
@@ -103,6 +109,7 @@ fd_first_pmemfile_pwrite(struct fd_association *file,
 		long count,
 		long offset)
 {
+	assert(!file->pool->suspended);
 	return wrapper_pmemfile_pwrite(file->pool->pool, file->file,
 		(const void *)buf,
 		(size_t)count,
@@ -114,6 +121,7 @@ fd_first_pmemfile_writev(struct fd_association *file,
 		long iov,
 		long iovcnt)
 {
+	assert(!file->pool->suspended);
 	return wrapper_pmemfile_writev(file->pool->pool, file->file,
 		(const pmemfile_iovec_t *)iov,
 		(int)iovcnt);
@@ -125,6 +133,7 @@ fd_first_pmemfile_pwritev(struct fd_association *file,
 		long iovcnt,
 		long offset)
 {
+	assert(!file->pool->suspended);
 	return wrapper_pmemfile_pwritev(file->pool->pool, file->file,
 		(const pmemfile_iovec_t *)iov,
 		(int)iovcnt,
@@ -136,6 +145,7 @@ fd_first_pmemfile_lseek(struct fd_association *file,
 		long offset,
 		long whence)
 {
+	assert(!file->pool->suspended);
 	return wrapper_pmemfile_lseek(file->pool->pool, file->file,
 		(pmemfile_off_t)offset,
 		(int)whence);
@@ -145,6 +155,7 @@ static inline int
 fd_first_pmemfile_fstat(struct fd_association *file,
 		long buf)
 {
+	assert(!file->pool->suspended);
 	return wrapper_pmemfile_fstat(file->pool->pool, file->file,
 		(pmemfile_stat_t *)buf);
 }
@@ -154,6 +165,7 @@ fd_first_pmemfile_getdents(struct fd_association *file,
 		long dirp,
 		long count)
 {
+	assert(!file->pool->suspended);
 	return wrapper_pmemfile_getdents(file->pool->pool, file->file,
 		(struct linux_dirent *)dirp,
 		(unsigned)count);
@@ -164,6 +176,7 @@ fd_first_pmemfile_getdents64(struct fd_association *file,
 		long dirp,
 		long count)
 {
+	assert(!file->pool->suspended);
 	return wrapper_pmemfile_getdents64(file->pool->pool, file->file,
 		(struct linux_dirent64 *)dirp,
 		(unsigned)count);
@@ -173,6 +186,7 @@ static inline int
 fd_first_pmemfile_fchmod(struct fd_association *file,
 		long mode)
 {
+	assert(!file->pool->suspended);
 	return wrapper_pmemfile_fchmod(file->pool->pool, file->file,
 		(pmemfile_mode_t)mode);
 }
@@ -182,6 +196,7 @@ fd_first_pmemfile_fchown(struct fd_association *file,
 		long owner,
 		long group)
 {
+	assert(!file->pool->suspended);
 	return wrapper_pmemfile_fchown(file->pool->pool, file->file,
 		(pmemfile_uid_t)owner,
 		(pmemfile_gid_t)group);
@@ -191,6 +206,7 @@ static inline int
 fd_first_pmemfile_ftruncate(struct fd_association *file,
 		long length)
 {
+	assert(!file->pool->suspended);
 	return wrapper_pmemfile_ftruncate(file->pool->pool, file->file,
 		(pmemfile_off_t)length);
 }
@@ -201,6 +217,7 @@ fd_first_pmemfile_fallocate(struct fd_association *file,
 		long offset,
 		long length)
 {
+	assert(!file->pool->suspended);
 	return wrapper_pmemfile_fallocate(file->pool->pool, file->file,
 		(int)mode,
 		(pmemfile_off_t)offset,
@@ -211,6 +228,7 @@ static inline int
 fd_first_pmemfile_flock(struct fd_association *file,
 		long operation)
 {
+	assert(!file->pool->suspended);
 	return wrapper_pmemfile_flock(file->pool->pool, file->file,
 		(int)operation);
 }

--- a/src/libpmemfile/libpmemfile-posix-wrappers.h
+++ b/src/libpmemfile/libpmemfile-posix-wrappers.h
@@ -1872,6 +1872,43 @@ wrapper_pmemfile_errormsg(void)
 }
 
 static inline int
+wrapper_pmemfile_pool_resume(PMEMfilepool *pfp,
+		const char *pathname)
+{
+	int ret;
+
+	ret = pmemfile_pool_resume(pfp,
+		pathname);
+	if (ret < 0)
+		ret = -errno;
+
+	log_write(
+	    "pmemfile_pool_resume(%p, \"%s\") = %d",
+		pfp,
+		pathname,
+		ret);
+
+	return ret;
+}
+
+static inline int
+wrapper_pmemfile_pool_suspend(PMEMfilepool *pfp)
+{
+	int ret;
+
+	ret = pmemfile_pool_suspend(pfp);
+	if (ret < 0)
+		ret = -errno;
+
+	log_write(
+	    "pmemfile_pool_suspend(%p) = %d",
+		pfp,
+		ret);
+
+	return ret;
+}
+
+static inline int
 wrapper_pmemfile_flock(PMEMfilepool *pfp,
 		PMEMfile *file,
 		int operation)

--- a/src/libpmemfile/libpmemfile-posix-wrappers.h
+++ b/src/libpmemfile/libpmemfile-posix-wrappers.h
@@ -85,6 +85,19 @@ wrapper_pmemfile_pool_close(PMEMfilepool *pfp)
 	pmemfile_pool_close(pfp);
 }
 
+static inline void
+wrapper_pmemfile_pool_set_device(PMEMfilepool *pfp,
+		pmemfile_dev_t dev)
+{
+	log_write(
+	    "pmemfile_pool_set_device(%p, %jx)",
+		pfp,
+		(uintmax_t)dev);
+
+	pmemfile_pool_set_device(pfp,
+		dev);
+}
+
 static inline PMEMfile *
 wrapper_pmemfile_create(PMEMfilepool *pfp,
 		const char *pathname,

--- a/src/libpmemfile/libpmemfile.map
+++ b/src/libpmemfile/libpmemfile.map
@@ -36,6 +36,10 @@
 # intentionally not exposing any symbols
 #
 {
+	global:
+		__xpg_strerror_r;
+		strerror_r;
+		strerror;
 	local:
 		*;
 };

--- a/src/libpmemfile/path_resolve.c
+++ b/src/libpmemfile/path_resolve.c
@@ -70,11 +70,15 @@ get_stat(struct resolved_path *result, struct stat *buf)
 			return -1;
 		}
 	} else {
-		int r = pmemfile_fstatat(result->at.pmem_fda.pool->pool,
-			result->at.pmem_fda.file,
-			result->path,
-			(pmemfile_stat_t *)buf,
+		struct pool_description *pool = result->at.pmem_fda.pool;
+
+		pool_acquire(pool);
+
+		int r = pmemfile_fstatat(pool->pool, result->at.pmem_fda.file,
+			result->path, (pmemfile_stat_t *)buf,
 			AT_SYMLINK_NOFOLLOW);
+
+		pool_release(pool);
 
 		if (r == 0) {
 			return 0;
@@ -115,11 +119,17 @@ resolve_symlink(struct resolved_path *result,
 			return;
 		}
 	} else {
-		link_len = pmemfile_readlinkat(result->at.pmem_fda.pool->pool,
+		struct pool_description *pool = result->at.pmem_fda.pool;
+
+		pool_acquire(pool);
+
+		link_len = pmemfile_readlinkat(pool->pool,
 				result->at.pmem_fda.file,
 				result->path,
 				link_buf,
 				sizeof(link_buf) - 1);
+
+		pool_release(pool);
 
 		if (link_len < 0) {
 			assert(errno != 0);

--- a/src/libpmemfile/preload.c
+++ b/src/libpmemfile/preload.c
@@ -2061,6 +2061,8 @@ open_new_pool_under_lock(struct pool_description *p)
 
 	update_capabilities(pfp);
 
+	pmemfile_pool_set_device(pfp, p->stat.st_dev);
+
 	if (pmemfile_stat(pfp, "/", &p->pmem_stat) != 0)
 		goto err;
 
@@ -2241,6 +2243,23 @@ config_error(const char *msg)
 	exit_with_msg(PMEMFILE_PRELOAD_EXIT_CONFIG_ERROR, msg);
 }
 
+static void
+set_mount_point(struct pool_description *pool, const char *path, size_t len)
+{
+	memcpy(pool->mount_point, path, len);
+	pool->mount_point[len] = '\0';
+
+	memcpy(pool->mount_point_parent, path, len);
+	pool->len_mount_point_parent = len;
+
+	while (pool->len_mount_point_parent > 1 &&
+	    pool->mount_point_parent[pool->len_mount_point_parent] != '/')
+		pool->len_mount_point_parent--;
+
+	pool->mount_point_parent[pool->len_mount_point_parent] = '\0';
+
+}
+
 static const char *
 parse_mount_point(struct pool_description *pool, const char *conf)
 {
@@ -2262,17 +2281,7 @@ parse_mount_point(struct pool_description *pool, const char *conf)
 			"invalid pmemfile config: too long mount point path");
 	}
 
-	memcpy(pool->mount_point, conf, (size_t)(colon - conf));
-	pool->mount_point[colon - conf] = '\0';
-
-	memcpy(pool->mount_point_parent, conf, (size_t)(colon - conf));
-	pool->len_mount_point_parent = (size_t)(colon - conf);
-
-	while (pool->len_mount_point_parent > 1 &&
-	    pool->mount_point_parent[pool->len_mount_point_parent] != '/')
-		pool->len_mount_point_parent--;
-
-	pool->mount_point_parent[pool->len_mount_point_parent] = '\0';
+	set_mount_point(pool, conf, (size_t)(colon - conf));
 
 	/* Return a pointer to the char following the colon */
 	return colon + 1;
@@ -2341,17 +2350,8 @@ open_mount_point(struct pool_description *pool)
 	}
 }
 
-/*
- * establish_mount_points - parse the configuration, which is expected to be a
- * semicolon separated list of path-pairs:
- * mount_point_path:pool_file_path
- * Mount point path is where the application is meant to observe a pmemfile
- * pool mounted -- this should be an actual directory accessible by the
- * application. The pool file path should point to the path of the actual
- * pmemfile pool.
- */
 static void
-establish_mount_points(const char *config)
+stat_cwd(struct stat *kernel_cwd_stat)
 {
 	char cwd[0x400];
 
@@ -2362,16 +2362,134 @@ establish_mount_points(const char *config)
 	if (getcwd(cwd, sizeof(cwd)) == NULL)
 		exit_with_msg(PMEMFILE_PRELOAD_EXIT_GETCWD_FAILED, "!getcwd");
 
-	struct stat kernel_cwd_stat;
-	if (stat(cwd, &kernel_cwd_stat) != 0) {
+	if (stat(cwd, kernel_cwd_stat) != 0) {
 		exit_with_msg(PMEMFILE_PRELOAD_EXIT_CWD_STAT_FAILED,
 				"!fstat cwd");
 	}
+}
 
-	assert(pool_count == 0);
+static void
+init_pool(struct pool_description *pool_desc, struct stat *kernel_cwd_stat)
+{
+	/* fetch pool_desc-fd, pool_desc->stat */
+	open_mount_point(pool_desc);
 
+	pool_desc->pool = NULL;
+
+	util_mutex_init(&pool_desc->pool_open_lock);
+	util_mutex_init(&pool_desc->process_switching_lock);
+
+	++pool_count;
+
+	/*
+	 * If the current working directory is a mount point, then
+	 * the corresponding pmemfile pool must opened at startup.
+	 * Normally, a pool is only opened the first time it is
+	 * accessed, but without doing this, the first access would
+	 * never be noticed.
+	 */
+	if (same_inode(&pool_desc->stat, kernel_cwd_stat)) {
+		open_new_pool(pool_desc);
+		if (pool_desc->pool == NULL) {
+			exit_with_msg(PMEMFILE_PRELOAD_EXIT_POOL_OPEN_FAILED,
+				"!opening pmemfile_pool");
+		}
+		cwd_pool = pool_desc;
+	}
+}
+
+static void
+detect_mount_points(struct stat *kernel_cwd_stat)
+{
+	FILE *file = fopen("/proc/self/mountinfo", "r");
+
+	if (!file)
+		return;
+
+	unsigned mount_id, parent_id, major, minor;
+	char root[PATH_MAX];
+	char mount_point[PATH_MAX];
+	char mount_options[4096];
+	char f[9][4096];
+	int matched = 0;
+	size_t len = PATH_MAX;
+	char *line = malloc(len);
+	if (!line) {
+		fclose(file);
+		return;
+	}
+
+	while (getline(&line, &len, file) > 0) {
+		matched = sscanf(line,
+			"%u %u %u:%u %s %s %s %[^\n ] %[^\n ] %[^\n ] %[^\n ] %[^\n ] %[^\n ] %[^\n ] %[^\n ] %[^\n ]",
+			&mount_id, &parent_id, &major, &minor, root,
+			mount_point, mount_options, f[0], f[1], f[2], f[3],
+			f[4], f[5], f[6], f[7], f[8]);
+
+		if (matched <= 0)
+			break;
+
+		int i;
+		for (i = 7; i < matched; ++i) {
+			if (strcmp(f[i - 7], "-") == 0) {
+				i++;
+				break;
+			}
+		}
+		if (i == matched)
+			continue;
+		const char *fstype = f[i - 7];
+		const char *mount_source = f[i - 7 + 1];
+		static const char prefix[] = "pmemfile:";
+
+		if (strcmp(fstype, "tmpfs") != 0)
+			continue;
+		if (strncmp(mount_source, prefix, strlen(prefix)) != 0)
+			continue;
+
+		log_write(
+			"matched:%d mount_id:%u parent_id:%u major:%u minor:%u root:%s mount_point:%s mount_options:%s",
+			matched, mount_id, parent_id, major, minor, root,
+			mount_point, mount_options);
+		for (int i = 7; i < matched; ++i)
+			log_write("f[%d]:%s", i - 7, f[i - 7]);
+		log_write("EOR");
+
+		size_t ret = strlen(mount_source + strlen(prefix));
+		strcpy(line, mount_source + strlen(prefix));
+
+		log_write("Using pool from '%s' to mount at '%s'.", line,
+				mount_point);
+
+		struct pool_description *pool = pools + pool_count;
+
+		set_mount_point(pool, mount_point, strlen(mount_point));
+
+		memcpy(pool->poolfile_path, line, (size_t)ret);
+		pool->poolfile_path[ret] = 0;
+
+		init_pool(pool, kernel_cwd_stat);
+	}
+
+	free(line);
+
+	fclose(file);
+}
+
+/*
+ * establish_mount_points - parse the configuration, which is expected to be a
+ * semicolon separated list of path-pairs:
+ * mount_point_path:pool_file_path
+ * Mount point path is where the application is meant to observe a pmemfile
+ * pool mounted -- this should be an actual directory accessible by the
+ * application. The pool file path should point to the path of the actual
+ * pmemfile pool.
+ */
+static void
+establish_mount_points(const char *config, struct stat *kernel_cwd_stat)
+{
 	if (config == NULL || config[0] == '\0') {
-		log_write("No mount point");
+		log_write("No mount information in PMEMFILE_POOLS.");
 		return;
 	}
 
@@ -2387,32 +2505,7 @@ establish_mount_points(const char *config)
 		/* fetch pool_desc->poolfile_path */
 		config = parse_pool_path(pool_desc, config);
 
-		/* fetch pool_desc-fd, pool_desc->stat */
-		open_mount_point(pool_desc);
-
-		pool_desc->pool = NULL;
-
-		util_mutex_init(&pool_desc->pool_open_lock);
-		util_mutex_init(&pool_desc->process_switching_lock);
-
-		++pool_count;
-
-		/*
-		 * If the current working directory is a mount point, then
-		 * the corresponding pmemfile pool must opened at startup.
-		 * Normally, a pool is only opened the first time it is
-		 * accessed, but without doing this, the first access would
-		 * never be noticed.
-		 */
-		if (same_inode(&pool_desc->stat, &kernel_cwd_stat)) {
-			open_new_pool(pool_desc);
-			if (pool_desc->pool == NULL) {
-				exit_with_msg(
-					PMEMFILE_PRELOAD_EXIT_POOL_OPEN_FAILED,
-					"!opening pmemfile_pool");
-			}
-			cwd_pool = pool_desc;
-		}
+		init_pool(pool_desc, kernel_cwd_stat);
 	} while (config != NULL);
 }
 
@@ -2437,7 +2530,12 @@ pmemfile_preload_constructor(void)
 	if (env_str)
 		process_switching = env_str[0] == '1';
 
-	establish_mount_points(getenv("PMEMFILE_POOLS"));
+	assert(pool_count == 0);
+	struct stat kernel_cwd_stat;
+	stat_cwd(&kernel_cwd_stat);
+
+	detect_mount_points(&kernel_cwd_stat);
+	establish_mount_points(getenv("PMEMFILE_POOLS"), &kernel_cwd_stat);
 
 	if (pool_count == 0)
 		/* No pools mounted. XXX prevent syscall interception */

--- a/src/libpmemfile/preload.c
+++ b/src/libpmemfile/preload.c
@@ -2530,6 +2530,12 @@ pmemfile_preload_constructor(void)
 	if (env_str)
 		process_switching = env_str[0] == '1';
 
+	if (getenv("PMEMFILE_PRELOAD_PAUSE_AT_START")) {
+		pause_at_start = 1;
+		while (pause_at_start)
+			;
+	}
+
 	assert(pool_count == 0);
 	struct stat kernel_cwd_stat;
 	stat_cwd(&kernel_cwd_stat);
@@ -2540,12 +2546,6 @@ pmemfile_preload_constructor(void)
 	if (pool_count == 0)
 		/* No pools mounted. XXX prevent syscall interception */
 		return;
-
-	if (getenv("PMEMFILE_PRELOAD_PAUSE_AT_START")) {
-		pause_at_start = 1;
-		while (pause_at_start)
-			;
-	}
 
 	/*
 	 * Must be the last step, the callback can be called anytime

--- a/src/libpmemfile/preload.c
+++ b/src/libpmemfile/preload.c
@@ -459,7 +459,7 @@ hook_fchdir(long fd)
 
 	long result;
 
-	log_write("%s(\"%ld\")", __func__, fd);
+	log_write("%s(%ld)", __func__, fd);
 
 	struct fd_association file = fd_ref(fd);
 

--- a/src/libpmemfile/preload.c
+++ b/src/libpmemfile/preload.c
@@ -66,6 +66,7 @@
 #include <utime.h>
 #include <sys/fsuid.h>
 #include <sys/capability.h>
+#include <dlfcn.h>
 
 #include <asm-generic/errno.h>
 
@@ -2243,6 +2244,8 @@ hook(long syscall_number,
 	return is_hooked;
 }
 
+static __thread bool guard_flag;
+
 /*
  * hook_reentrance_guard_wrapper -- a wrapper which can notice reentrance.
  *
@@ -2262,8 +2265,6 @@ hook_reentrance_guard_wrapper(long syscall_number,
 				long arg4, long arg5,
 				long *syscall_return_value)
 {
-	static __thread bool guard_flag = false;
-
 	if (guard_flag)
 		return NOT_HOOKED;
 
@@ -2558,6 +2559,72 @@ establish_mount_points(const char *config, struct stat *kernel_cwd_stat)
 	} while (config != NULL);
 }
 
+static int (*libc__xpg_strerror_r)(int __errnum, char *__buf, size_t __buflen);
+static char *(*libc_strerror_r)(int __errnum, char *__buf, size_t __buflen);
+static char *(*libc_strerror)(int __errnum);
+
+int __xpg_strerror_r(int __errnum, char *__buf, size_t __buflen);
+
+/*
+ * XSI-compliant version of strerror_r. We have to override it to handle
+ * possible deadlock/infinite recursion when pmemfile is called from inside of
+ * strerror_r implementation and we call back into libc because of some failure
+ * (notably: pool opening failed when process switching is enabled).
+ */
+int
+__xpg_strerror_r(int __errnum, char *__buf, size_t __buflen)
+{
+	if (!guard_flag && libc__xpg_strerror_r)
+		return libc__xpg_strerror_r(__errnum, __buf, __buflen);
+
+	if (__errnum == EAGAIN) {
+		const char *str =
+			"Resource temporary unavailable (pmemfile wrapper)";
+		if (__buflen < strlen(str) + 1)
+			return ERANGE;
+		strcpy(__buf, str);
+		return 0;
+	}
+
+	const char *str = "Error code %d (pmemfile wrapper)";
+	if (__buflen < strlen(str) + 10)
+		return ERANGE;
+	sprintf(__buf, str, __errnum);
+
+	return 0;
+}
+
+/*
+ * GNU-compliant version of strerror_r. See __xpg_strerror_r description.
+ */
+char *
+strerror_r(int __errnum, char *__buf, size_t __buflen)
+{
+	if (!guard_flag && libc_strerror_r)
+		return libc_strerror_r(__errnum, __buf, __buflen);
+
+	const char *str = "Error code %d (pmemfile wrapper)";
+	if (__buflen < strlen(str) + 10)
+		return NULL;
+
+	sprintf(__buf, str, __errnum);
+	return __buf;
+}
+
+/*
+ * See __xpg_strerror_r description.
+ */
+char *
+strerror(int __errnum)
+{
+	static char buf[100];
+	if (!guard_flag && libc_strerror)
+		return libc_strerror(__errnum);
+
+	sprintf(buf, "Error code %d (pmemfile wrapper)", __errnum);
+	return buf;
+}
+
 static volatile int pause_at_start;
 
 pf_constructor void
@@ -2595,6 +2662,18 @@ pmemfile_preload_constructor(void)
 	if (pool_count == 0)
 		/* No pools mounted. XXX prevent syscall interception */
 		return;
+
+	libc__xpg_strerror_r = dlsym(RTLD_NEXT, "__xpg_strerror_r");
+	if (!libc__xpg_strerror_r)
+		FATAL("!can't find __xpg_strerror_r");
+
+	libc_strerror_r = dlsym(RTLD_NEXT, "strerror_r");
+	if (!libc_strerror_r)
+		FATAL("!can't find strerror_r");
+
+	libc_strerror = dlsym(RTLD_NEXT, "strerror");
+	if (!libc_strerror)
+		FATAL("!can't find strerror");
 
 	/*
 	 * Must be the last step, the callback can be called anytime

--- a/src/libpmemfile/preload.c
+++ b/src/libpmemfile/preload.c
@@ -79,6 +79,7 @@
 #include "libpmemfile-posix-fd_first.h"
 
 static long log_fd = -1;
+static bool process_switching;
 
 static void
 log_init(const char *path, const char *trunc)
@@ -134,6 +135,52 @@ static bool is_memfd_syscall_available;
 #define RWF_SYNC 0x00000004
 #endif
 
+/*
+ * pool_acquire -- acquires access to pool
+ */
+void
+pool_acquire(struct pool_description *pool)
+{
+	if (!process_switching)
+		return;
+
+	util_mutex_lock(&pool->process_switching_lock);
+	pool->ref_cnt++;
+
+	if (pool->ref_cnt == 1 && pool->suspended) {
+		if (pmemfile_pool_resume(pool->pool, pool->poolfile_path))
+			FATAL("could not restore pmemfile pool");
+		pool->suspended = false;
+	}
+
+	util_mutex_unlock(&pool->process_switching_lock);
+}
+
+/*
+ * pool_release -- releases access to pool
+ */
+void
+pool_release(struct pool_description *pool)
+{
+	if (!process_switching)
+		return;
+
+	int oerrno = errno;
+
+	util_mutex_lock(&pool->process_switching_lock);
+	pool->ref_cnt--;
+
+	if (pool->ref_cnt == 0 && !pool->suspended) {
+		if (pmemfile_pool_suspend(pool->pool))
+			FATAL("could not suspend pmemfile pool");
+		pool->suspended = true;
+	}
+
+	util_mutex_unlock(&pool->process_switching_lock);
+
+	errno = oerrno;
+}
+
 struct pmemfile_entry {
 	struct fd_association pmemfile;
 	int ref_count;
@@ -173,7 +220,13 @@ fd_unref(long fd, struct fd_association *file)
 	if (__sync_sub_and_fetch(&fd_table[fd].ref_count, 1) == 0) {
 		(void) syscall_no_intercept(SYS_close, fd);
 
+		struct pool_description *pool = file->pool;
+
+		pool_acquire(pool);
+
 		fd_first_pmemfile_close(file);
+
+		pool_release(pool);
 	}
 }
 
@@ -365,11 +418,16 @@ hook_linkat(long fd0, long arg0, long fd1, long arg1, long flags)
 		    where_old.at.kernel_fd, where_old.path,
 		    where_new.at.kernel_fd, where_new.path, flags);
 	} else {
-		int r = wrapper_pmemfile_linkat(
-			    where_old.at.pmem_fda.pool->pool,
+		struct pool_description *pool = where_old.at.pmem_fda.pool;
+
+		pool_acquire(pool);
+
+		int r = wrapper_pmemfile_linkat(pool->pool,
 			    where_old.at.pmem_fda.file, where_old.path,
 			    where_new.at.pmem_fda.file, where_new.path,
 				(int)flags);
+
+		pool_release(pool);
 
 		ret = check_errno(r, SYS_linkat);
 	}
@@ -398,8 +456,14 @@ hook_unlinkat(long fd, long path_arg, long flags)
 		ret = syscall_no_intercept(SYS_unlinkat,
 				where.at.kernel_fd, where.path, flags);
 	} else {
-		int r = wrapper_pmemfile_unlinkat(where.at.pmem_fda.pool->pool,
+		struct pool_description *pool = where.at.pmem_fda.pool;
+
+		pool_acquire(pool);
+
+		int r = wrapper_pmemfile_unlinkat(pool->pool,
 			where.at.pmem_fda.file, where.path, (int)flags);
+
+		pool_release(pool);
 
 		ret = check_errno(r, SYS_unlinkat);
 	}
@@ -435,6 +499,8 @@ hook_chdir(const char *path)
 			syscall_no_intercept(SYS_chdir, cwd_pool->mount_point);
 		}
 
+		pool_acquire(cwd_pool);
+
 		if (pmemfile_chdir(cwd_pool->pool, where.path) == 0)
 			result = 0;
 		else
@@ -442,6 +508,8 @@ hook_chdir(const char *path)
 
 		log_write("pmemfile_chdir(%p, \"%s\") = %ld",
 		    cwd_pool->pool, where.path, result);
+
+		pool_release(cwd_pool);
 
 		check_errno(result, SYS_chdir);
 	}
@@ -466,15 +534,21 @@ hook_fchdir(long fd)
 	util_rwlock_wrlock(&pmem_cwd_lock);
 
 	if (!is_fda_null(&file)) {
-		if (pmemfile_fchdir(file.pool->pool, file.file) == 0) {
+		struct pool_description *pool = file.pool;
+
+		pool_acquire(pool);
+
+		if (pmemfile_fchdir(pool->pool, file.file) == 0) {
 			cwd_pool = file.pool;
 			result = 0;
 		} else {
 			result = -errno;
 		}
 
-		log_write("pmemfile_fchdir(%p, %p) = %ld",
-			file.pool->pool, file.file, result);
+		log_write("pmemfile_fchdir(%p, %p) = %ld", pool->pool,
+				file.file, result);
+
+		pool_release(pool);
 
 		check_errno(result, SYS_fchdir);
 	} else {
@@ -502,10 +576,18 @@ hook_getcwd(char *buf, size_t size)
 
 	strcpy(buf, cwd_pool->mount_point);
 
-	if (pmemfile_getcwd(cwd_pool->pool, buf + mlen, size - mlen) == NULL)
-		return check_errno(-errno, SYS_getcwd);
+	long ret;
 
-	return 0;
+	pool_acquire(cwd_pool);
+
+	if (pmemfile_getcwd(cwd_pool->pool, buf + mlen, size - mlen) == NULL)
+		ret = check_errno(-errno, SYS_getcwd);
+	else
+		ret = 0;
+
+	pool_release(cwd_pool);
+
+	return ret;
 }
 
 static long
@@ -526,10 +608,16 @@ hook_newfstatat(long fd, long arg0, long arg1, long arg2)
 		ret = syscall_no_intercept(SYS_newfstatat,
 		    where.at.kernel_fd, where.path, arg1, arg2);
 	} else {
-		int r = wrapper_pmemfile_fstatat(where.at.pmem_fda.pool->pool,
+		struct pool_description *pool = where.at.pmem_fda.pool;
+
+		pool_acquire(pool);
+
+		int r = wrapper_pmemfile_fstatat(pool->pool,
 			where.at.pmem_fda.file,
 			where.path,
 			(pmemfile_stat_t *)arg1, (int)arg2);
+
+		pool_release(pool);
 
 		ret = check_errno(r, SYS_newfstatat);
 	}
@@ -555,8 +643,14 @@ hook_faccessat(long fd, long path_arg, long mode)
 		ret = syscall_no_intercept(SYS_faccessat,
 		    where.at.kernel_fd, where.path, mode);
 	} else {
-		int r = wrapper_pmemfile_faccessat(where.at.pmem_fda.pool->pool,
+		struct pool_description *pool = where.at.pmem_fda.pool;
+
+		pool_acquire(pool);
+
+		int r = wrapper_pmemfile_faccessat(pool->pool,
 			where.at.pmem_fda.file, where.path, (int)mode, 0);
+
+		pool_release(pool);
 
 		ret = check_errno(r, SYS_faccessat);
 	}
@@ -619,8 +713,14 @@ hook_mkdirat(long fd, long path_arg, long mode)
 		ret = syscall_no_intercept(SYS_mkdirat,
 		    where.at.kernel_fd, where.path, mode);
 	} else {
-		long r = wrapper_pmemfile_mkdirat(where.at.pmem_fda.pool->pool,
+		struct pool_description *pool = where.at.pmem_fda.pool;
+
+		pool_acquire(pool);
+
+		long r = wrapper_pmemfile_mkdirat(pool->pool,
 			where.at.pmem_fda.file, where.path, (mode_t)mode);
+
+		pool_release(pool);
 
 		ret = check_errno(r, SYS_mkdirat);
 	}
@@ -633,19 +733,24 @@ hook_mkdirat(long fd, long path_arg, long mode)
 static long
 openat_helper(long fd, struct resolved_path *where, long flags, long mode)
 {
-	PMEMfile *file = pmemfile_openat(where->at.pmem_fda.pool->pool,
+	struct pool_description *pool = where->at.pmem_fda.pool;
+
+	pool_acquire(pool);
+
+	PMEMfile *file = pmemfile_openat(pool->pool,
 					where->at.pmem_fda.file,
 					where->path,
 					((int)flags) & ~O_NONBLOCK,
 					(mode_t)mode);
 
 	log_write("pmemfile_openat(%p, %p, \"%s\", 0x%x, %u) = %p",
-					(void *)where->at.pmem_fda.pool->pool,
-					(void *)where->at.pmem_fda.file,
+					pool->pool,
+					where->at.pmem_fda.file,
 					where->path,
 					((int)flags) & ~O_NONBLOCK,
 					(mode_t)mode,
 					file);
+	pool_release(pool);
 
 	if (file == NULL) {
 		(void) syscall_no_intercept(SYS_close, fd);
@@ -713,6 +818,7 @@ hook_openat(long fd_at, long arg0, long flags, long mode)
 static long
 hook_fcntl(struct fd_association *file, int cmd, long arg)
 {
+	assert(!file->pool->suspended);
 	int r = pmemfile_fcntl(file->pool->pool, file->file, cmd, arg);
 
 	if (r < 0)
@@ -756,11 +862,16 @@ hook_renameat2(long fd_old, const char *path_old, long fd_new,
 			    where_new.at.kernel_fd, where_new.path, flags);
 		}
 	} else {
-		int r = wrapper_pmemfile_renameat2(
-				where_old.at.pmem_fda.pool->pool,
+		struct pool_description *pool = where_old.at.pmem_fda.pool;
+
+		pool_acquire(pool);
+
+		int r = wrapper_pmemfile_renameat2(pool->pool,
 				where_old.at.pmem_fda.file, where_old.path,
 				where_new.at.pmem_fda.file, where_new.path,
 				flags);
+
+		pool_release(pool);
 
 		ret = check_errno(r, SYS_renameat2);
 	}
@@ -784,8 +895,13 @@ hook_truncate(const char *path, off_t length)
 		return syscall_no_intercept(SYS_truncate,
 		    where.at.kernel_fd, where.path, length);
 
-	int r = wrapper_pmemfile_truncate(where.at.pmem_fda.pool->pool,
-					where.path, length);
+	struct pool_description *pool = where.at.pmem_fda.pool;
+
+	pool_acquire(pool);
+
+	int r = wrapper_pmemfile_truncate(pool->pool, where.path, length);
+
+	pool_release(pool);
 
 	return check_errno(r, SYS_truncate);
 }
@@ -805,9 +921,15 @@ hook_symlinkat(const char *target, long fd, const char *linkpath)
 		ret = syscall_no_intercept(SYS_symlinkat, target,
 		    where.at.kernel_fd, where.path);
 	} else {
-		int r = wrapper_pmemfile_symlinkat(where.at.pmem_fda.pool->pool,
+		struct pool_description *pool = where.at.pmem_fda.pool;
+
+		pool_acquire(pool);
+
+		int r = wrapper_pmemfile_symlinkat(pool->pool,
 				target,
 				where.at.pmem_fda.file, where.path);
+
+		pool_release(pool);
 
 		ret = check_errno(r, SYS_symlinkat);
 	}
@@ -833,8 +955,14 @@ hook_fchmodat(long fd, const char *path, mode_t mode)
 		ret = syscall_no_intercept(SYS_fchmodat,
 		    where.at.kernel_fd, where.path, mode);
 	} else {
-		int r = wrapper_pmemfile_fchmodat(where.at.pmem_fda.pool->pool,
+		struct pool_description *pool = where.at.pmem_fda.pool;
+
+		pool_acquire(pool);
+
+		int r = wrapper_pmemfile_fchmodat(pool->pool,
 				where.at.pmem_fda.file, where.path, mode, 0);
+
+		pool_release(pool);
 
 		ret = check_errno(r, SYS_fchmodat);
 	}
@@ -863,9 +991,15 @@ hook_fchownat(long fd, const char *path,
 		ret = syscall_no_intercept(SYS_fchownat,
 		    where.at.kernel_fd, where.path, owner, group, flags);
 	} else {
+		struct pool_description *pool = where.at.pmem_fda.pool;
+
+		pool_acquire(pool);
+
 		int r = wrapper_pmemfile_fchownat(where.at.pmem_fda.pool->pool,
 				where.at.pmem_fda.file, where.path, owner,
 				group, flags);
+
+		pool_release(pool);
 
 		ret = check_errno(r, SYS_fchownat);
 	}
@@ -903,10 +1037,15 @@ hook_readlinkat(long fd, const char *path, char *buf, size_t bufsiz)
 		ret = syscall_no_intercept(SYS_readlinkat,
 		    where.at.kernel_fd, where.path, buf, bufsiz);
 	} else {
-		ssize_t r = wrapper_pmemfile_readlinkat(
-				where.at.pmem_fda.pool->pool,
+		struct pool_description *pool = where.at.pmem_fda.pool;
+
+		pool_acquire(pool);
+
+		ssize_t r = wrapper_pmemfile_readlinkat(pool->pool,
 				where.at.pmem_fda.file, where.path, buf,
 				bufsiz);
+
+		pool_release(pool);
 
 		assert(r < INT_MAX);
 
@@ -967,8 +1106,12 @@ hook_futimesat(long fd, const char *path,
 		ret = syscall_no_intercept(SYS_futimesat,
 				where.at.kernel_fd, where.path, times);
 	} else {
-		int r = pmemfile_futimesat(where.at.pmem_fda.pool->pool,
-				where.at.pmem_fda.file, where.path, times);
+		struct pool_description *pool = where.at.pmem_fda.pool;
+
+		pool_acquire(pool);
+
+		int r = pmemfile_futimesat(pool->pool, where.at.pmem_fda.file,
+				where.path, times);
 
 		if (r != 0)
 			r = -errno;
@@ -976,16 +1119,16 @@ hook_futimesat(long fd, const char *path,
 		if (times) {
 			log_write(
 				"pmemfile_futimesat(%p, %p, \"%s\", [%ld,%ld,%ld,%ld]) = %d",
-			    (void *) where.at.pmem_fda.pool->pool,
-			    (void *) where.at.pmem_fda.file, where.path,
+			    pool->pool, where.at.pmem_fda.file, where.path,
 			    times[0].tv_sec, times[0].tv_usec, times[1].tv_sec,
 			    times[1].tv_usec, r);
 		} else {
 			log_write(
 				"pmemfile_futimesat(%p, %p, \"%s\", NULL) = %d",
-			    (void *) where.at.pmem_fda.pool->pool,
-			    (void *) where.at.pmem_fda.file, where.path, r);
+			    pool->pool, where.at.pmem_fda.file, where.path, r);
 		}
+
+		pool_release(pool);
 
 		ret = check_errno(r, SYS_futimesat);
 	}
@@ -1026,6 +1169,10 @@ utimensat_helper(int sc, long fd, const char *path,
 			 */
 			ret = -EINVAL;
 		} else if (path == NULL) {
+			struct pool_description *pool = where.at.pmem_fda.pool;
+
+			pool_acquire(pool);
+
 			/*
 			 * Linux nonstandard syscall-level feature. Glibc
 			 * behaves differently, but we have to emulate kernel
@@ -1034,7 +1181,7 @@ utimensat_helper(int sc, long fd, const char *path,
 			 * See "C library/ kernel ABI differences"
 			 * section in man utimensat.
 			 */
-			r = pmemfile_futimens(where.at.pmem_fda.pool->pool,
+			r = pmemfile_futimens(pool->pool,
 					where.at.pmem_fda.file, times);
 
 			if (r != 0)
@@ -1043,44 +1190,46 @@ utimensat_helper(int sc, long fd, const char *path,
 			if (times) {
 				log_write(
 					"pmemfile_futimens(%p, %p, [%ld,%ld,%ld,%ld]) = %d",
-					(void *) where.at.pmem_fda.pool->pool,
-					(void *) where.at.pmem_fda.file,
+					pool->pool, where.at.pmem_fda.file,
 					times[0].tv_sec, times[0].tv_nsec,
 					times[1].tv_sec, times[1].tv_nsec, r);
 			} else {
 				log_write(
 					"pmemfile_futimens(%p, %p, NULL) = %d",
-					(void *) where.at.pmem_fda.pool->pool,
-					(void *) where.at.pmem_fda.file, r);
+					pool->pool, where.at.pmem_fda.file, r);
 
 			}
 
-			ret = check_errno(r, sc);
+			pool_release(pool);
 
+			ret = check_errno(r, sc);
 		} else {
-			r = pmemfile_utimensat(where.at.pmem_fda.pool->pool,
-			    where.at.pmem_fda.file, where.path, times,
-			    flags);
+			struct pool_description *pool = where.at.pmem_fda.pool;
+
+			pool_acquire(pool);
+
+			r = pmemfile_utimensat(pool->pool,
+				where.at.pmem_fda.file, where.path, times,
+				flags);
 
 			if (r != 0)
 				r = -errno;
 
 			if (times) {
 				log_write(
-				    "pmemfile_utimensat(%p, %p, \"%s\", [%ld,%ld,%ld,%ld], %d)"
-				    " = %d",
-				    (void *) where.at.pmem_fda.pool->pool,
-				    (void *) where.at.pmem_fda.file, where.path,
-				    times[0].tv_sec, times[0].tv_nsec,
-				    times[1].tv_sec, times[1].tv_nsec, flags,
-					r);
+				    "pmemfile_utimensat(%p, %p, \"%s\", [%ld,%ld,%ld,%ld], %d) = %d",
+				    pool->pool, where.at.pmem_fda.file,
+				    where.path, times[0].tv_sec,
+				    times[0].tv_nsec, times[1].tv_sec,
+				    times[1].tv_nsec, flags, r);
 			} else {
 				log_write(
 				    "pmemfile_utimensat(%p, %p, \"%s\", NULL, %d) = %d",
-				    (void *) where.at.pmem_fda.pool->pool,
-				    (void *) where.at.pmem_fda.file,
+				    pool->pool, where.at.pmem_fda.file,
 				    where.path, flags, r);
 			}
+
+			pool_release(pool);
 
 			ret = check_errno(r, sc);
 		}
@@ -1220,9 +1369,15 @@ hook_mknodat(long fd, const char *path, mode_t mode, dev_t dev)
 		ret = syscall_no_intercept(SYS_mknodat,
 		    where.at.kernel_fd, where.path, mode, dev);
 	} else {
-		long r = wrapper_pmemfile_mknodat(where.at.pmem_fda.pool->pool,
+		struct pool_description *pool = where.at.pmem_fda.pool;
+
+		pool_acquire(pool);
+
+		long r = wrapper_pmemfile_mknodat(pool->pool,
 		    where.at.pmem_fda.file, where.path, (mode_t) mode,
 		    (dev_t) dev);
+
+		pool_release(pool);
 
 		ret = check_errno(r, SYS_mknodat);
 	}
@@ -1856,7 +2011,11 @@ open_new_pool_under_lock(struct pool_description *p)
 	if (p->pool != NULL)
 		return; /* already open */
 
-	if ((pfp = pmemfile_pool_open(p->poolfile_path)) == NULL)
+	do {
+		pfp = pmemfile_pool_open(p->poolfile_path);
+	} while (pfp == NULL && process_switching && errno == EAGAIN);
+
+	if (pfp == NULL)
 		return; /* failed to open */
 
 	if (pmemfile_setreuid(pfp, getuid(), geteuid()))
@@ -2007,12 +2166,16 @@ hook(long syscall_number,
 			*syscall_return_value =
 			    check_errno(-ENOTSUP, syscall_number);
 		} else {
+			pool_acquire(file.pool);
+
 			*syscall_return_value =
 			    dispatch_syscall_fd_first(syscall_number,
 			    &file, arg1, arg2, arg3, arg4, arg5);
 
 			*syscall_return_value =
 			    check_errno(*syscall_return_value, syscall_number);
+
+			pool_release(file.pool);
 		}
 
 		if (!is_fda_null(&file))
@@ -2230,6 +2393,7 @@ establish_mount_points(const char *config)
 		pool_desc->pool = NULL;
 
 		util_mutex_init(&pool_desc->pool_open_lock);
+		util_mutex_init(&pool_desc->process_switching_lock);
 
 		++pool_count;
 
@@ -2266,7 +2430,12 @@ pmemfile_preload_constructor(void)
 			getenv("PMEMFILE_PRELOAD_LOG_TRUNC"));
 
 	const char *env_str = getenv("PMEMFILE_EXIT_ON_NOT_SUPPORTED");
-	exit_on_ENOTSUP = env_str ? env_str[0] == '1' : 0;
+	if (env_str)
+		exit_on_ENOTSUP = env_str[0] == '1';
+
+	env_str = getenv("PMEMFILE_PRELOAD_PROCESS_SWITCHING");
+	if (env_str)
+		process_switching = env_str[0] == '1';
 
 	establish_mount_points(getenv("PMEMFILE_POOLS"));
 

--- a/src/libpmemfile/preload.h
+++ b/src/libpmemfile/preload.h
@@ -83,6 +83,10 @@ struct pool_description {
 	 */
 	struct pmemfilepool *pool;
 
+	pthread_mutex_t process_switching_lock;
+	int ref_cnt;
+	bool suspended;
+
 	/* Data about the root directory inside the pmemfile pool */
 	struct stat pmem_stat;
 };
@@ -136,5 +140,8 @@ void resolve_path(struct fd_desc at,
 			int flags);
 
 pf_printf_like(1, 2) void log_write(const char *fmt, ...);
+
+void pool_acquire(struct pool_description *pool);
+void pool_release(struct pool_description *pool);
 
 #endif

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -35,7 +35,14 @@ target_link_libraries(mkfs.pmemfile pmemfile-posix_shared)
 add_executable(pmemfile-cat pmemfile-cat.c)
 target_link_libraries(pmemfile-cat pmemfile-posix_shared)
 
+add_executable(pmemfile-mount pmemfile-mount.c)
+
 install(TARGETS mkfs.pmemfile
+	CONFIGURATIONS Release None RelWithDebInfo
+	DESTINATION ${CMAKE_INSTALL_BINDIR}
+	PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+
+install(TARGETS pmemfile-mount
 	CONFIGURATIONS Release None RelWithDebInfo
 	DESTINATION ${CMAKE_INSTALL_BINDIR}
 	PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)

--- a/src/tools/pmemfile-mount.c
+++ b/src/tools/pmemfile-mount.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * pmemfile-mount.c -- pmemfile mount command source file
+ */
+
+#include <getopt.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mount.h>
+
+static const char *progname;
+
+static void
+print_version(void)
+{
+	puts("pmemfile-mount v1");
+}
+
+static void
+print_usage(FILE *stream)
+{
+	fprintf(stream,
+	    "Usage: %s [-v] [-h] pool-path mount-point\n"
+	    "Options:\n"
+	    "  -v      print version\n"
+	    "  -h      print this help text\n",
+	    progname);
+}
+
+
+int
+main(int argc, char *argv[])
+{
+	int opt;
+	const char *pool_path;
+	const char *mount_point;
+
+	progname = argv[0];
+
+	while ((opt = getopt(argc, argv, "vh")) >= 0) {
+		switch (opt) {
+		case 'v':
+		case 'V':
+			print_version();
+			return 0;
+		case 'h':
+		case 'H':
+			print_usage(stdout);
+			return 0;
+		default:
+			print_usage(stderr);
+			return 2;
+		}
+	}
+
+	if (optind + 2 > argc) {
+		print_usage(stderr);
+		return 2;
+	}
+
+	pool_path = argv[optind];
+	mount_point = argv[optind + 1];
+
+	char mount_source[PATH_MAX];
+	sprintf(mount_source, "pmemfile:%s", pool_path);
+
+	if (mount(mount_source, mount_point, "tmpfs",
+			MS_NODEV | MS_NOEXEC | MS_NOSUID | MS_RELATIME,
+			"size=4k")) {
+		perror("mount");
+		return 1;
+	}
+
+	return 0;
+}

--- a/tests/posix/pmemfile_test.cpp
+++ b/tests/posix/pmemfile_test.cpp
@@ -53,11 +53,11 @@ test_pmemfile_stats_match(PMEMfilepool *pfp, unsigned inodes, unsigned dirs,
 	EXPECT_EQ(stats.inodes, inodes);
 	EXPECT_EQ(stats.dirs, dirs);
 	EXPECT_EQ(stats.block_arrays, block_arrays);
-	EXPECT_EQ(stats.inode_arrays, (unsigned)1);
+	EXPECT_EQ(stats.inode_arrays, 2u);
 	EXPECT_EQ(stats.blocks, blocks);
 
 	return stats.inodes == inodes && stats.dirs == dirs &&
-		stats.block_arrays == block_arrays && stats.inode_arrays == 1 &&
+		stats.block_arrays == block_arrays && stats.inode_arrays == 2 &&
 		stats.blocks == blocks;
 }
 

--- a/tests/preload/CMakeLists.txt
+++ b/tests/preload/CMakeLists.txt
@@ -54,6 +54,8 @@ int main() {
 }
 " XATTR_AVAILABLE_IN_TEST_DIR)
 
+option(TEST_PROCESS_SWITCHING "test process switching using preload tests" OFF)
+
 add_executable(preload_basic basic/basic.c)
 add_executable(preload_config config/config.c)
 add_executable(preload_pool_locking pool_locking/pool_locking.c)
@@ -98,6 +100,7 @@ function(add_test_generic name sub_name main_executable)
 			-DBIN_DIR=${CMAKE_CURRENT_BINARY_DIR}/${name}${sub_name}
 			-DPRELOAD_LIB=${PRELOAD_LIB_LIST}
 			-DMAIN_EXECUTABLE=${main_executable}
+			-DTEST_PROCESS_SWITCHING=${TEST_PROCESS_SWITCHING}
 			${ARGN}
 			-P ${CMAKE_CURRENT_SOURCE_DIR}/${name}/${name}.cmake)
 

--- a/tests/preload/pool_locking/pool_locking.cmake
+++ b/tests/preload/pool_locking/pool_locking.cmake
@@ -39,8 +39,11 @@ execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${DIR}/mount_point)
 
 set(ENV{LD_PRELOAD} ${PRELOAD_LIB})
 set(ENV{PMEMFILE_POOLS} ${DIR}/mount_point:${DIR}/fs)
-set(ENV{PMEMFILE_PRELOAD_LOG} ${BIN_DIR}/pmemfile_preload.log)
-set(ENV{INTERCEPT_LOG} ${BIN_DIR}/intercept.log)
+
+if (NOT TEST_PROCESS_SWITCHING)
+	set(ENV{PMEMFILE_PRELOAD_LOG} ${BIN_DIR}/pmemfile_preload.log)
+	set(ENV{INTERCEPT_LOG} ${BIN_DIR}/intercept.log)
+endif()
 
 execute(${MAIN_EXECUTABLE} ${DIR}/mount_point/file)
 

--- a/tests/preload/preload-helpers.cmake
+++ b/tests/preload/preload-helpers.cmake
@@ -34,6 +34,10 @@ include(${SRC_DIR}/../../helpers.cmake)
 function(setup)
 	common_setup()
 
+	if (TEST_PROCESS_SWITCHING)
+		set(ENV{PMEMFILE_PRELOAD_PROCESS_SWITCHING} 1)
+	endif()
+
 	if(TESTS_USE_FORCED_PMEM)
 		set(ENV{PMEM_IS_PMEM_FORCE} 1)
 	endif()

--- a/utils/transform/transform_pmemfile_posix_fd_first.c
+++ b/utils/transform/transform_pmemfile_posix_fd_first.c
@@ -131,7 +131,7 @@ print_prototype(const struct func_desc *desc, FILE *f)
 
 /*
  * print_forward_args -- prints the list of variables to be passed as arguments
- * to the orignal function. E.g.:
+ * to the original function. E.g.:
  *
  * +------------------------------------+
  * | file->pool->pool, file->file,      |
@@ -184,6 +184,7 @@ print_wrapper(struct func_desc *desc, FILE *f)
 {
 	print_prototype(desc, f);
 	fputs("{\n", f);
+	fputs("\tassert(!file->pool->suspended);\n", f);
 	print_forward_call(desc, f);
 	fputs("}\n\n", f);
 }


### PR DESCRIPTION
Process switching is a feature that allows us to test pmemfile using test suites which require multi-process support. It's very slow and NOT intended for production use. It's implemented by opening pmemobj pool when it's needed and closing it when it's not. Before closing the pool we are marking all opened inodes as "suspended" (by increasing persistent suspended_references counter and putting them on a global list, so they won't disappear while another process accesses the pool) and unmarking them after open. As pmemobj pool can be mapped at different address, after open we fix all pointers to persistent memory from our runtime structures.

pmemfile-mount is a new command that allows users to skip setting PMEMFILE_POOLS environment variable. It mounts tmpfs file system at specified directory and passes "pmemfile:${path_to_pool}" as a source device, which tmpfs ignores, but is recorded by the kernel. It allows us to automatically detect pmemfile mount points by looking at /proc/self/mountinfo.
(Example line from mountinfo:
``210 22 0:43 / /mnt/pmemfile rw,nosuid,nodev,noexec,relatime shared:157 - tmpfs pmemfile:/dev/dax0.0 rw,size=4k)``
It requires root, but greatly simplifies pmemfile setup.

pmemfile-mount was needed, because df command was crashing with pmemfile. It stat'ed pmemfile directory and tried to find stat.st_dev in /proc/self/mountinfo, which resulted in segmentation fault (which is actually df bug). Mounting tmpfs allocated new device id which we could use as st_dev (that's what pmemfile_pool_set_device entry point is for). 

Testing this feature with pjdfstest uncovered more bugs:
- chdir didn't propagate to forked processes
- utimensat(fd, NULL, times, 0) was handled incorrectly, which resulted in "touch" command failing
- failed pmemobj_opens (when another process is accessing the pool) were hanging because of deadlock

The last issue is a manifestation of #263 and is temporarily worked around by overriding strerror[_r] functions. We have to find a better way to fix it.

Note that none of the bug fixes in this PR are caused by process switching - they fix already existing bugs we were not able to hit previously.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/279)
<!-- Reviewable:end -->
