### PR TITLE
posix: set dir_pos.dir pointer in PMEMfile struct

### DIFF
--- a/src/libpmemfile-posix/file.c
+++ b/src/libpmemfile-posix/file.c
@@ -474,6 +474,8 @@ _pmemfile_openat(PMEMfilepool *pfp, struct pmemfile_vinode *dir,
 		goto end;
 
 	file->vinode = vinode;
+	if (vinode_is_dir(vinode))
+		file->dir_pos.dir = &vinode->inode->file_data.dir;
 
 end:
 	path_info_cleanup(pfp, &info);


### PR DESCRIPTION
If somebody has a better name for this commit, please write it :)

This PR fixes a bug which occured when calling getdents for first time with offset different than 0.
file->dir_pos.dir was being not assigned by _pmemfile_openat (file.c:177)

Case when this bug occurs:
- open a directory with some files or directories inside
- set offset with lseek to '1'
- call pmemfile_getdents
- getdents will return 0 instead of buffer with entries

Case when this bug will not occur:
- open a directory with some files or directories inside
- call pmemfile_getdents (default offset is 0)
- getdents will return buffer with entries
- set offset with lseek to '1'
- getdents will return buffer with one less entry than first call - works OK

I added a test for this - getdents.cpp:303. 
Also I added some code for testing if getdents work properly with other offsets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/285)
<!-- Reviewable:end -->
