### PR TITLE
vfd_table and dup

### DIFF
--- a/src/libpmemfile/CMakeLists.txt
+++ b/src/libpmemfile/CMakeLists.txt
@@ -29,7 +29,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-set(SOURCES path_resolve.c preload.c syscall_early_filter.c)
+set(SOURCES path_resolve.c preload.c syscall_early_filter.c vfd_table.c)
 
 if(PKG_CONFIG_FOUND)
 	pkg_check_modules(SYSCALL_INTERCEPT libsyscall_intercept)

--- a/src/libpmemfile/libpmemfile-posix-fd_first.h
+++ b/src/libpmemfile/libpmemfile-posix-fd_first.h
@@ -38,14 +38,14 @@
 #include "libpmemfile-posix-wrappers.h"
 
 static inline void
-fd_first_pmemfile_close(struct fd_association *file)
+fd_first_pmemfile_close(struct vfd_reference *file)
 {
 	assert(!file->pool->suspended);
 	wrapper_pmemfile_close(file->pool->pool, file->file);
 }
 
 static inline pmemfile_ssize_t
-fd_first_pmemfile_read(struct fd_association *file,
+fd_first_pmemfile_read(struct vfd_reference *file,
 		long buf,
 		long count)
 {
@@ -56,7 +56,7 @@ fd_first_pmemfile_read(struct fd_association *file,
 }
 
 static inline pmemfile_ssize_t
-fd_first_pmemfile_pread(struct fd_association *file,
+fd_first_pmemfile_pread(struct vfd_reference *file,
 		long buf,
 		long count,
 		long offset)
@@ -69,7 +69,7 @@ fd_first_pmemfile_pread(struct fd_association *file,
 }
 
 static inline pmemfile_ssize_t
-fd_first_pmemfile_readv(struct fd_association *file,
+fd_first_pmemfile_readv(struct vfd_reference *file,
 		long iov,
 		long iovcnt)
 {
@@ -80,7 +80,7 @@ fd_first_pmemfile_readv(struct fd_association *file,
 }
 
 static inline pmemfile_ssize_t
-fd_first_pmemfile_preadv(struct fd_association *file,
+fd_first_pmemfile_preadv(struct vfd_reference *file,
 		long iov,
 		long iovcnt,
 		long offset)
@@ -93,7 +93,7 @@ fd_first_pmemfile_preadv(struct fd_association *file,
 }
 
 static inline pmemfile_ssize_t
-fd_first_pmemfile_write(struct fd_association *file,
+fd_first_pmemfile_write(struct vfd_reference *file,
 		long buf,
 		long count)
 {
@@ -104,7 +104,7 @@ fd_first_pmemfile_write(struct fd_association *file,
 }
 
 static inline pmemfile_ssize_t
-fd_first_pmemfile_pwrite(struct fd_association *file,
+fd_first_pmemfile_pwrite(struct vfd_reference *file,
 		long buf,
 		long count,
 		long offset)
@@ -117,7 +117,7 @@ fd_first_pmemfile_pwrite(struct fd_association *file,
 }
 
 static inline pmemfile_ssize_t
-fd_first_pmemfile_writev(struct fd_association *file,
+fd_first_pmemfile_writev(struct vfd_reference *file,
 		long iov,
 		long iovcnt)
 {
@@ -128,7 +128,7 @@ fd_first_pmemfile_writev(struct fd_association *file,
 }
 
 static inline pmemfile_ssize_t
-fd_first_pmemfile_pwritev(struct fd_association *file,
+fd_first_pmemfile_pwritev(struct vfd_reference *file,
 		long iov,
 		long iovcnt,
 		long offset)
@@ -141,7 +141,7 @@ fd_first_pmemfile_pwritev(struct fd_association *file,
 }
 
 static inline pmemfile_off_t
-fd_first_pmemfile_lseek(struct fd_association *file,
+fd_first_pmemfile_lseek(struct vfd_reference *file,
 		long offset,
 		long whence)
 {
@@ -152,7 +152,7 @@ fd_first_pmemfile_lseek(struct fd_association *file,
 }
 
 static inline int
-fd_first_pmemfile_fstat(struct fd_association *file,
+fd_first_pmemfile_fstat(struct vfd_reference *file,
 		long buf)
 {
 	assert(!file->pool->suspended);
@@ -161,7 +161,7 @@ fd_first_pmemfile_fstat(struct fd_association *file,
 }
 
 static inline int
-fd_first_pmemfile_getdents(struct fd_association *file,
+fd_first_pmemfile_getdents(struct vfd_reference *file,
 		long dirp,
 		long count)
 {
@@ -172,7 +172,7 @@ fd_first_pmemfile_getdents(struct fd_association *file,
 }
 
 static inline int
-fd_first_pmemfile_getdents64(struct fd_association *file,
+fd_first_pmemfile_getdents64(struct vfd_reference *file,
 		long dirp,
 		long count)
 {
@@ -183,7 +183,7 @@ fd_first_pmemfile_getdents64(struct fd_association *file,
 }
 
 static inline int
-fd_first_pmemfile_fchmod(struct fd_association *file,
+fd_first_pmemfile_fchmod(struct vfd_reference *file,
 		long mode)
 {
 	assert(!file->pool->suspended);
@@ -192,7 +192,7 @@ fd_first_pmemfile_fchmod(struct fd_association *file,
 }
 
 static inline int
-fd_first_pmemfile_fchown(struct fd_association *file,
+fd_first_pmemfile_fchown(struct vfd_reference *file,
 		long owner,
 		long group)
 {
@@ -203,7 +203,7 @@ fd_first_pmemfile_fchown(struct fd_association *file,
 }
 
 static inline int
-fd_first_pmemfile_ftruncate(struct fd_association *file,
+fd_first_pmemfile_ftruncate(struct vfd_reference *file,
 		long length)
 {
 	assert(!file->pool->suspended);
@@ -212,7 +212,7 @@ fd_first_pmemfile_ftruncate(struct fd_association *file,
 }
 
 static inline int
-fd_first_pmemfile_fallocate(struct fd_association *file,
+fd_first_pmemfile_fallocate(struct vfd_reference *file,
 		long mode,
 		long offset,
 		long length)
@@ -225,7 +225,7 @@ fd_first_pmemfile_fallocate(struct fd_association *file,
 }
 
 static inline int
-fd_first_pmemfile_flock(struct fd_association *file,
+fd_first_pmemfile_flock(struct vfd_reference *file,
 		long operation)
 {
 	assert(!file->pool->suspended);

--- a/src/libpmemfile/path_resolve.c
+++ b/src/libpmemfile/path_resolve.c
@@ -57,12 +57,10 @@
 static int
 get_stat(struct resolved_path *result, struct stat *buf)
 {
-	if (is_fda_null(&result->at.pmem_fda)) {
+	if (result->at_pool == NULL) {
 		long error_code = syscall_no_intercept(SYS_newfstatat,
-			result->at.kernel_fd,
-			result->path,
-			buf,
-			AT_SYMLINK_NOFOLLOW);
+					result->at_kernel, result->path,
+					buf, AT_SYMLINK_NOFOLLOW);
 		if (error_code == 0) {
 			return 0;
 		} else {
@@ -70,15 +68,14 @@ get_stat(struct resolved_path *result, struct stat *buf)
 			return -1;
 		}
 	} else {
-		struct pool_description *pool = result->at.pmem_fda.pool;
+		pool_acquire(result->at_pool);
 
-		pool_acquire(pool);
+		int r = pmemfile_fstatat(result->at_pool->pool,
+					result->at_dir, result->path,
+					(pmemfile_stat_t *)buf,
+					AT_SYMLINK_NOFOLLOW);
 
-		int r = pmemfile_fstatat(pool->pool, result->at.pmem_fda.file,
-			result->path, (pmemfile_stat_t *)buf,
-			AT_SYMLINK_NOFOLLOW);
-
-		pool_release(pool);
+		pool_release(result->at_pool);
 
 		if (r == 0) {
 			return 0;
@@ -107,9 +104,9 @@ resolve_symlink(struct resolved_path *result,
 
 	result->path[*end] = '\0';
 
-	if (is_fda_null(&result->at.pmem_fda)) {
+	if (result->at_pool == NULL) {
 		link_len = syscall_no_intercept(SYS_readlinkat,
-			result->at.kernel_fd,
+			result->at_kernel,
 			result->path,
 			link_buf,
 			sizeof(link_buf) - 1);
@@ -119,17 +116,15 @@ resolve_symlink(struct resolved_path *result,
 			return;
 		}
 	} else {
-		struct pool_description *pool = result->at.pmem_fda.pool;
+		pool_acquire(result->at_pool);
 
-		pool_acquire(pool);
-
-		link_len = pmemfile_readlinkat(pool->pool,
-				result->at.pmem_fda.file,
+		link_len = pmemfile_readlinkat(result->at_pool->pool,
+				result->at_dir,
 				result->path,
 				link_buf,
 				sizeof(link_buf) - 1);
 
-		pool_release(pool);
+		pool_release(result->at_pool);
 
 		if (link_len < 0) {
 			assert(errno != 0);
@@ -224,7 +219,7 @@ resolve_symlink(struct resolved_path *result,
 	*resolved = link_insert;
 
 	if (link_buf[0] == '/')
-		result->at.pmem_fda.pool = NULL;
+		result->at_pool = NULL;
 }
 
 /*
@@ -238,8 +233,14 @@ enter_pool(struct resolved_path *result, struct pool_description *pool,
 {
 	memmove(result->path, result->path + end, *size - end);
 	result->path[0] = '/';
-	result->at.pmem_fda.pool = pool;
-	result->at.pmem_fda.file = PMEMFILE_AT_CWD;
+	result->at_pool = pool;
+
+	/*
+	 * The at_dir field doesn't matter here, since result->path
+	 * refers to an absolute path.
+	 */
+	result->at_dir = PMEMFILE_AT_CWD;
+
 	*resolved = 1;
 	*size -= end;
 	if (*size == 0)
@@ -255,8 +256,8 @@ enter_pool(struct resolved_path *result, struct pool_description *pool,
 static void
 exit_pool(struct resolved_path *result, size_t resolved, size_t *size)
 {
-	result->at.kernel_fd = result->at.pmem_fda.pool->fd;
-	result->at.pmem_fda.pool = NULL;
+	result->at_kernel = result->at_pool->fd;
+	result->at_pool = NULL;
 	memmove(result->path, result->path + resolved, *size - resolved + 1);
 	*size -= resolved;
 }
@@ -270,7 +271,7 @@ exit_pool(struct resolved_path *result, size_t resolved, size_t *size)
  * via the kernel.
  */
 void
-resolve_path(struct fd_desc at,
+resolve_path(struct vfd_reference at,
 			const char *path,
 			struct resolved_path *result,
 			int flags)
@@ -280,7 +281,9 @@ resolve_path(struct fd_desc at,
 		return;
 	}
 
-	result->at = at;
+	result->at_kernel = at.kernel_fd;
+	result->at_pool = at.pool;
+	result->at_dir = at.file;
 	result->error_code = 0;
 
 	size_t resolved; /* How many chars are resolved already? */
@@ -294,10 +297,8 @@ resolve_path(struct fd_desc at,
 	if (get_stat(result, &stat_buf) != 0)
 		return;
 
-	const struct fd_association *pmem_fda = &result->at.pmem_fda;
-
-	bool at_pmem_root = pmem_fda->pool &&
-			same_inode(&stat_buf, &pmem_fda->pool->pmem_stat);
+	bool at_pmem_root = at.pool &&
+			same_inode(&stat_buf, &at.pool->pmem_stat);
 
 	for (size = 0; path[size] != '\0'; ++size) {
 		/* leave one more byte for the null terminator */
@@ -322,7 +323,7 @@ resolve_path(struct fd_desc at,
 	result->path[size] = '\0';
 
 	if (path[0] == '/')
-		result->at.pmem_fda.pool = NULL;
+		result->at_pool = NULL;
 
 	int num_symlinks = 0;
 	struct pool_description *last_pool = NULL;
@@ -361,8 +362,6 @@ resolve_path(struct fd_desc at,
 		if (get_stat(result, &stat_buf) != 0)
 			break;
 
-		pmem_fda = &result->at.pmem_fda;
-
 		if (!is_last_component)
 			result->path[end] = '/';
 
@@ -373,7 +372,7 @@ resolve_path(struct fd_desc at,
 		 */
 		if (at_pmem_root && (end - resolved) == 2 &&
 				memcmp(&result->path[resolved], "..", 2) == 0) {
-			last_pool = result->at.pmem_fda.pool;
+			last_pool = result->at_pool;
 			exit_pool(result, resolved, &size);
 			at_pmem_root = false;
 			continue;
@@ -400,7 +399,7 @@ resolve_path(struct fd_desc at,
 				result->error_code = -ENOTDIR;
 
 			break;
-		} else if (is_fda_null(pmem_fda)) {
+		} else if (result->at_pool == NULL) {
 			struct pool_description *pool;
 
 			pool = lookup_pd_by_inode(&stat_buf);
@@ -414,7 +413,7 @@ resolve_path(struct fd_desc at,
 				continue;
 			}
 		} else {
-			if (same_inode(&stat_buf, &pmem_fda->pool->pmem_stat))
+			if (same_inode(&stat_buf, &result->at_pool->pmem_stat))
 				at_pmem_root = true;
 		}
 
@@ -434,8 +433,10 @@ resolve_path(struct fd_desc at,
 	 * interfaces that do not have *at variant, then prepend the path with
 	 * the mount point path.
 	 */
-	if (result->error_code == 0 && is_fda_null(&result->at.pmem_fda) &&
-			(flags & NO_AT_PATH) && last_pool) {
+	if (result->error_code == 0 &&
+			result->at_pool == NULL &&
+			(flags & NO_AT_PATH) &&
+			last_pool) {
 		size_t rem_len = strlen(result->path);
 		size_t mnt_len = strlen(last_pool->mount_point);
 

--- a/src/libpmemfile/preload.c
+++ b/src/libpmemfile/preload.c
@@ -1830,6 +1830,12 @@ dispatch_syscall(long syscall_number,
 		return hook_bind((int)arg0, (const struct sockaddr *)arg1,
 				(socklen_t)arg2);
 
+	case SYS_dup:
+		return pmemfile_vfd_dup((int)arg0);
+
+	case SYS_dup2:
+		return pmemfile_vfd_dup2((int)arg0, (int)arg1);
+
 	default:
 		/* Did we miss something? */
 		assert(false);

--- a/src/libpmemfile/preload.c
+++ b/src/libpmemfile/preload.c
@@ -2077,6 +2077,19 @@ hook(long syscall_number,
 		return HOOKED;
 	}
 
+	if (syscall_number == SYS_fcntl &&
+	    ((int)arg1 == F_DUPFD || (int)arg1 == F_DUPFD_CLOEXEC)) {
+		/*
+		 * Other fcntl commands on pmemfile resident files are handled
+		 * via dispatch_syscall_fd_first.
+		 *
+		 * XXX: close-on-exec flag is not handled correctly yet.
+		 */
+		*syscall_return_value =
+		    pmemfile_vfd_fcntl_dup((int)arg0, (int)arg2);
+		return HOOKED;
+	}
+
 	struct syscall_early_filter_entry filter_entry;
 	filter_entry = get_early_filter_entry(syscall_number);
 

--- a/src/libpmemfile/preload.c
+++ b/src/libpmemfile/preload.c
@@ -117,10 +117,10 @@ log_write(const char *fmt, ...)
 	syscall_no_intercept(SYS_write, log_fd, buf, len);
 }
 
+static pthread_mutex_t cwd_mutex = PTHREAD_MUTEX_INITIALIZER;
+
 static struct pool_description pools[0x100];
 static int pool_count;
-
-static bool is_memfd_syscall_available;
 
 #define PMEMFILE_MAX_FD 0x8000
 
@@ -182,17 +182,6 @@ pool_release(struct pool_description *pool)
 	errno = oerrno;
 }
 
-struct pmemfile_entry {
-	struct fd_association pmemfile;
-	int ref_count;
-};
-
-/*
- * The associations between user visible fd numbers and
- * pmemfile pointers. Each pmemfile fd has it's own reference counter.
- */
-static struct pmemfile_entry fd_table[PMEMFILE_MAX_FD + 1];
-
 /*
  * A separate place to keep track of fds used to hold mount points open, in
  * the previous array. The application should not be aware of these, thus
@@ -200,91 +189,6 @@ static struct pmemfile_entry fd_table[PMEMFILE_MAX_FD + 1];
  * must be returned. The contents of this array does not change after startup.
  */
 static bool mount_point_fds[PMEMFILE_MAX_FD + 1];
-
-static bool
-is_fd_in_table(long fd)
-{
-	if (fd < 0 || fd > PMEMFILE_MAX_FD)
-		return false;
-
-	return !is_fda_null(&fd_table[fd].pmemfile);
-}
-
-static pthread_rwlock_t pmem_cwd_lock = PTHREAD_RWLOCK_INITIALIZER;
-static struct pool_description *volatile cwd_pool;
-
-static pthread_mutex_t fd_table_mutex = PTHREAD_MUTEX_INITIALIZER;
-
-static void
-fd_unref(long fd, struct fd_association *file)
-{
-	if (__sync_sub_and_fetch(&fd_table[fd].ref_count, 1) == 0) {
-		(void) syscall_no_intercept(SYS_close, fd);
-
-		struct pool_description *pool = file->pool;
-
-		pool_acquire(pool);
-
-		fd_first_pmemfile_close(file);
-
-		pool_release(pool);
-	}
-}
-
-static struct fd_association
-fd_ref(long fd)
-{
-	struct fd_association file;
-	file.file = NULL;
-	file.pool = NULL;
-
-	util_mutex_lock(&fd_table_mutex);
-
-	if (is_fd_in_table(fd)) {
-		__sync_add_and_fetch(&fd_table[fd].ref_count, 1);
-		file = fd_table[fd].pmemfile;
-	}
-
-	util_mutex_unlock(&fd_table_mutex);
-
-	return file;
-}
-
-static struct fd_desc
-cwd_desc(void)
-{
-	struct fd_desc result;
-
-	result.kernel_fd = AT_FDCWD;
-	result.pmem_fda.pool = cwd_pool;
-	result.pmem_fda.file = PMEMFILE_AT_CWD;
-
-	return result;
-}
-
-static struct fd_desc
-fd_fetch(long fd)
-{
-	struct fd_desc result;
-
-	result.kernel_fd = fd;
-
-	if ((int)fd == AT_FDCWD) {
-		result.pmem_fda.pool = cwd_pool;
-		result.pmem_fda.file = PMEMFILE_AT_CWD;
-	} else {
-		result.pmem_fda = fd_ref(fd);
-	}
-
-	return result;
-}
-
-static void
-fd_release(struct fd_desc *at)
-{
-	if (!is_fda_null(&at->pmem_fda) && at->pmem_fda.file != PMEMFILE_AT_CWD)
-		fd_unref(at->kernel_fd, &at->pmem_fda);
-}
 
 static int exit_on_ENOTSUP;
 static long check_errno(long e, long syscall_no)
@@ -298,52 +202,6 @@ static long check_errno(long e, long syscall_no)
 	}
 
 	return e;
-}
-
-#ifdef SYS_memfd_create
-
-static void
-check_memfd_syscall(void)
-{
-	long fd = syscall_no_intercept(SYS_memfd_create, "check", 0);
-	if (fd >= 0) {
-		is_memfd_syscall_available = true;
-		syscall_no_intercept(SYS_close, fd);
-	}
-}
-
-#else
-
-#define SYS_memfd_create 0
-#define check_memfd_syscall()
-
-#endif
-
-/*
- * acquire_new_fd - grab a new file descriptor from the kernel
- */
-static long
-acquire_new_fd(const char *path)
-{
-	long fd;
-
-	if (is_memfd_syscall_available) {
-		fd = syscall_no_intercept(SYS_memfd_create, path, 0);
-		/* memfd_create can fail for too long name */
-		if (fd < 0) {
-			fd = syscall_no_intercept(SYS_open, "/dev/null",
-					O_RDONLY);
-		}
-	} else {
-		fd = syscall_no_intercept(SYS_open, "/dev/null", O_RDONLY);
-	}
-
-	if (fd > PMEMFILE_MAX_FD) {
-		syscall_no_intercept(SYS_close, fd);
-		return -ENFILE;
-	}
-
-	return fd;
 }
 
 void
@@ -368,40 +226,14 @@ exit_with_msg(int ret, const char *msg)
 }
 
 static long
-hook_close(long fd)
-{
-	bool is_fd_pmem = false;
-	struct fd_association file;
-
-	util_mutex_lock(&fd_table_mutex);
-
-	if (is_fd_in_table(fd)) {
-		file = fd_table[fd].pmemfile;
-		fd_table[fd].pmemfile.file = NULL;
-		fd_table[fd].pmemfile.pool = NULL;
-
-		is_fd_pmem = true;
-	}
-
-	util_mutex_unlock(&fd_table_mutex);
-
-	if (is_fd_pmem)
-		fd_unref(fd, &file);
-	else
-		(void) syscall_no_intercept(SYS_close, fd);
-
-	return 0;
-}
-
-static long
-hook_linkat(long fd0, long arg0, long fd1, long arg1, long flags)
+hook_linkat(int fd0, long arg0, int fd1, long arg1, long flags)
 {
 	long ret;
 	struct resolved_path where_old;
 	struct resolved_path where_new;
 
-	struct fd_desc at0 = fd_fetch(fd0);
-	struct fd_desc at1 = fd_fetch(fd1);
+	struct vfd_reference at0 = pmemfile_vfd_at_ref(fd0);
+	struct vfd_reference at1 = pmemfile_vfd_at_ref(fd1);
 
 	resolve_path(at0, (const char *)arg0, &where_old, RESOLVE_LAST_SLINK);
 	resolve_path(at1, (const char *)arg1, &where_new,
@@ -411,65 +243,62 @@ hook_linkat(long fd0, long arg0, long fd1, long arg1, long flags)
 		ret = where_old.error_code;
 	} else if (where_new.error_code != 0) {
 		ret = where_new.error_code;
-	} else if (where_new.at.pmem_fda.pool != where_old.at.pmem_fda.pool) {
+	} else if (where_new.at_pool != where_old.at_pool) {
 		/* cross-pool link are not possible */
 		ret = -EXDEV;
-	} else if (is_fda_null(&where_new.at.pmem_fda)) {
+	} else if (where_new.at_pool == NULL) {
 		ret = syscall_no_intercept(SYS_linkat,
-		    where_old.at.kernel_fd, where_old.path,
-		    where_new.at.kernel_fd, where_new.path, flags);
+		    where_old.at_kernel, where_old.path,
+		    where_new.at_kernel, where_new.path, flags);
 	} else {
-		struct pool_description *pool = where_old.at.pmem_fda.pool;
+		pool_acquire(where_old.at_pool);
 
-		pool_acquire(pool);
-
-		int r = wrapper_pmemfile_linkat(pool->pool,
-			    where_old.at.pmem_fda.file, where_old.path,
-			    where_new.at.pmem_fda.file, where_new.path,
+		int r = wrapper_pmemfile_linkat(
+			    where_old.at_pool->pool,
+			    where_old.at_dir, where_old.path,
+			    where_new.at_dir, where_new.path,
 				(int)flags);
 
-		pool_release(pool);
+		pool_release(where_old.at_pool);
 
 		ret = check_errno(r, SYS_linkat);
 	}
 
-	fd_release(&at0);
-	fd_release(&at1);
+	pmemfile_vfd_unref(at0);
+	pmemfile_vfd_unref(at1);
 
 	return ret;
 }
 
 static long
-hook_unlinkat(long fd, long path_arg, long flags)
+hook_unlinkat(int fd, long path_arg, long flags)
 {
 	long ret;
 	struct resolved_path where;
 
-	struct fd_desc at = fd_fetch(fd);
+	struct vfd_reference at = pmemfile_vfd_at_ref(fd);
 
 	resolve_path(at, (const char *)path_arg,
 	    &where, NO_RESOLVE_LAST_SLINK);
 
 	if (where.error_code != 0) {
 		ret = where.error_code;
-	} else if (is_fda_null(&where.at.pmem_fda)) {
+	} else if (where.at_pool == NULL) {
 		/* Not pmemfile resident path */
 		ret = syscall_no_intercept(SYS_unlinkat,
-				where.at.kernel_fd, where.path, flags);
+				where.at_kernel, where.path, flags);
 	} else {
-		struct pool_description *pool = where.at.pmem_fda.pool;
+		pool_acquire(where.at_pool);
 
-		pool_acquire(pool);
+		int r = wrapper_pmemfile_unlinkat(where.at_pool->pool,
+			where.at_dir, where.path, (int)flags);
 
-		int r = wrapper_pmemfile_unlinkat(pool->pool,
-			where.at.pmem_fda.file, where.path, (int)flags);
-
-		pool_release(pool);
+		pool_release(where.at_pool);
 
 		ret = check_errno(r, SYS_unlinkat);
 	}
 
-	fd_release(&at);
+	pmemfile_vfd_unref(at);
 
 	return ret;
 
@@ -478,126 +307,99 @@ hook_unlinkat(long fd, long path_arg, long flags)
 static long
 hook_chdir(const char *path)
 {
+	util_mutex_lock(&cwd_mutex);
 	struct resolved_path where;
 
 	long result;
 
 	log_write("%s(\"%s\")", __func__, path);
 
-	util_rwlock_wrlock(&pmem_cwd_lock);
-
-	resolve_path(cwd_desc(), path, &where, RESOLVE_LAST_SLINK);
+	struct vfd_reference at = pmemfile_vfd_at_ref(AT_FDCWD);
+	resolve_path(at, path, &where, RESOLVE_LAST_SLINK);
 
 	if (where.error_code != 0) {
 		result = where.error_code;
-	} else if (is_fda_null(&where.at.pmem_fda)) {
-		result = syscall_no_intercept(SYS_chdir, where.path);
-		if (result == 0)
-			cwd_pool = NULL;
-	} else {
-		if (cwd_pool != where.at.pmem_fda.pool) {
-			cwd_pool = where.at.pmem_fda.pool;
-			syscall_no_intercept(SYS_chdir, cwd_pool->mount_point);
-		}
+	} else if (where.at_pool == NULL) {
+		long fd = syscall_no_intercept(SYS_openat,
+				where.at_kernel, where.path,
+				O_DIRECTORY | O_PATH | O_NOCTTY);
 
-		pool_acquire(cwd_pool);
-
-		if (pmemfile_chdir(cwd_pool->pool, where.path) == 0)
-			result = 0;
+		if (fd >= 0)
+			result = pmemfile_vfd_chdir_kernel_fd((int)fd);
 		else
+			result = fd;
+	} else {
+		pool_acquire(where.at_pool);
+
+		PMEMfile *file = pmemfile_openat(where.at_pool->pool,
+					where.at_dir, where.path,
+					O_DIRECTORY | O_PATH | O_NOCTTY);
+
+		if (file == NULL) {
 			result = -errno;
-
-		log_write("pmemfile_chdir(%p, \"%s\") = %ld",
-		    cwd_pool->pool, where.path, result);
-
-		pool_release(cwd_pool);
-
-		check_errno(result, SYS_chdir);
-	}
-
-	util_rwlock_unlock(&pmem_cwd_lock);
-
-	return result;
-}
-
-static long
-hook_fchdir(long fd)
-{
-	if (fd == AT_FDCWD)
-		return 0;
-
-	long result;
-
-	log_write("%s(%ld)", __func__, fd);
-
-	struct fd_association file = fd_ref(fd);
-
-	util_rwlock_wrlock(&pmem_cwd_lock);
-
-	if (!is_fda_null(&file)) {
-		struct pool_description *pool = file.pool;
-
-		pool_acquire(pool);
-
-		if (pmemfile_fchdir(pool->pool, file.file) == 0) {
-			cwd_pool = file.pool;
-			result = 0;
 		} else {
-			result = -errno;
+			result = pmemfile_vfd_chdir_pf(where.at_pool, file);
+			if (result != 0)
+				pmemfile_close(where.at_pool->pool, file);
 		}
 
-		log_write("pmemfile_fchdir(%p, %p) = %ld", pool->pool,
-				file.file, result);
+		pool_release(where.at_pool);
 
-		pool_release(pool);
-
-		check_errno(result, SYS_fchdir);
-	} else {
-		result = syscall_no_intercept(SYS_fchdir, fd);
-		if (result == 0)
-			cwd_pool = NULL;
+		result = check_errno(result, SYS_chdir);
 	}
 
-	util_rwlock_unlock(&pmem_cwd_lock);
+	pmemfile_vfd_unref(at);
 
-	fd_unref(fd, &file);
+	util_mutex_unlock(&cwd_mutex);
 
 	return result;
 }
 
 static long
-hook_getcwd(char *buf, size_t size)
+hook_pool_getcwd(struct pool_description *pool, char *buf, size_t size)
 {
-	if (cwd_pool == NULL)
+	if (pool == NULL)
 		return syscall_no_intercept(SYS_getcwd, buf, size);
 
-	size_t mlen = strlen(cwd_pool->mount_point);
+	size_t mlen = strlen(pool->mount_point);
 	if (mlen >= size)
 		return -ERANGE;
 
-	strcpy(buf, cwd_pool->mount_point);
+	strcpy(buf, pool->mount_point);
 
-	long ret;
+	long ret = 0;
 
-	pool_acquire(cwd_pool);
+	pool_acquire(pool);
 
-	if (pmemfile_getcwd(cwd_pool->pool, buf + mlen, size - mlen) == NULL)
+	if (pmemfile_getcwd(pool->pool, buf + mlen, size - mlen) == NULL)
 		ret = check_errno(-errno, SYS_getcwd);
-	else
-		ret = 0;
 
-	pool_release(cwd_pool);
+	pool_release(pool);
 
 	return ret;
 }
 
 static long
-hook_newfstatat(long fd, long arg0, long arg1, long arg2)
+hook_getcwd(char *buf, size_t size)
+{
+	util_mutex_lock(&cwd_mutex);
+	struct vfd_reference at = pmemfile_vfd_at_ref(AT_FDCWD);
+
+	long result = hook_pool_getcwd(at.pool, buf, size);
+
+	pmemfile_vfd_unref(at);
+	util_mutex_unlock(&cwd_mutex);
+
+	return result;
+}
+
+static long
+hook_newfstatat(int fd, long arg0, long arg1, long arg2)
 {
 	long ret;
 	struct resolved_path where;
 
-	struct fd_desc at = fd_fetch(fd);
+	struct vfd_reference at = pmemfile_vfd_at_ref(fd);
 
 	resolve_path(at, (const char *)arg0, &where,
 	    (arg2 & AT_SYMLINK_NOFOLLOW)
@@ -605,58 +407,53 @@ hook_newfstatat(long fd, long arg0, long arg1, long arg2)
 
 	if (where.error_code != 0) {
 		ret = where.error_code;
-	} else if (is_fda_null(&where.at.pmem_fda)) {
+	} else if (where.at_pool == NULL) {
 		ret = syscall_no_intercept(SYS_newfstatat,
-		    where.at.kernel_fd, where.path, arg1, arg2);
+		    where.at_kernel, where.path, arg1, arg2);
 	} else {
-		struct pool_description *pool = where.at.pmem_fda.pool;
+		pool_acquire(where.at_pool);
 
-		pool_acquire(pool);
-
-		int r = wrapper_pmemfile_fstatat(pool->pool,
-			where.at.pmem_fda.file,
-			where.path,
+		int r = wrapper_pmemfile_fstatat(where.at_pool->pool,
+			where.at_dir, where.path,
 			(pmemfile_stat_t *)arg1, (int)arg2);
 
-		pool_release(pool);
+		pool_release(where.at_pool);
 
 		ret = check_errno(r, SYS_newfstatat);
 	}
 
-	fd_release(&at);
+	pmemfile_vfd_unref(at);
 
 	return ret;
 }
 
 static long
-hook_faccessat(long fd, long path_arg, long mode)
+hook_faccessat(int fd, long path_arg, long mode)
 {
 	long ret;
 	struct resolved_path where;
 
-	struct fd_desc at = fd_fetch(fd);
+	struct vfd_reference at = pmemfile_vfd_ref(fd);
 
 	resolve_path(at, (const char *)path_arg, &where, NO_RESOLVE_LAST_SLINK);
 
 	if (where.error_code != 0) {
 		ret = where.error_code;
-	} else if (is_fda_null(&where.at.pmem_fda)) {
+	} else if (where.at_pool == NULL) {
 		ret = syscall_no_intercept(SYS_faccessat,
-		    where.at.kernel_fd, where.path, mode);
+		    where.at_kernel, where.path, mode);
 	} else {
-		struct pool_description *pool = where.at.pmem_fda.pool;
+		pool_acquire(where.at_pool);
 
-		pool_acquire(pool);
+		int r = wrapper_pmemfile_faccessat(where.at_pool->pool,
+			where.at_dir, where.path, (int)mode, 0);
 
-		int r = wrapper_pmemfile_faccessat(pool->pool,
-			where.at.pmem_fda.file, where.path, (int)mode, 0);
-
-		pool_release(pool);
+		pool_release(where.at_pool);
 
 		ret = check_errno(r, SYS_faccessat);
 	}
 
-	fd_release(&at);
+	pmemfile_vfd_unref(at);
 
 	return ret;
 }
@@ -665,112 +462,123 @@ static long
 hook_getxattr(long arg0, long arg1, long arg2, long arg3,
 		int resolve_last)
 {
+	long result;
 	struct resolved_path where;
 
-	resolve_path(cwd_desc(), (const char *)arg0, &where,
+	struct vfd_reference at = pmemfile_vfd_at_ref(AT_FDCWD);
+
+	resolve_path(at, (const char *)arg0, &where,
 			resolve_last | NO_AT_PATH);
 
 	if (where.error_code != 0)
-		return where.error_code;
+		result = where.error_code;
+	else if (where.at_pool != NULL)
+		result = check_errno(-ENOTSUP, SYS_getxattr);
+	else
+		result = syscall_no_intercept(SYS_getxattr, where.path,
+						arg1, arg2, arg3);
 
-	if (!is_fda_null(&where.at.pmem_fda))
-		return check_errno(-ENOTSUP, SYS_getxattr);
+	pmemfile_vfd_unref(at);
 
-	return syscall_no_intercept(SYS_getxattr, where.path, arg1, arg2, arg3);
+	return result;
 }
 
 static long
 hook_setxattr(long arg0, long arg1, long arg2, long arg3, long arg4,
 		int resolve_last)
 {
+	long result;
 	struct resolved_path where;
 
-	resolve_path(cwd_desc(), (const char *)arg0, &where,
+	struct vfd_reference at = pmemfile_vfd_at_ref(AT_FDCWD);
+
+	resolve_path(at, (const char *)arg0, &where,
 			resolve_last | NO_AT_PATH);
 
 	if (where.error_code != 0)
-		return where.error_code;
+		result = where.error_code;
+	else if (where.at_pool != NULL)
+		result = check_errno(-ENOTSUP, SYS_setxattr);
+	else
+		result = syscall_no_intercept(SYS_setxattr, where.path,
+						arg1, arg2, arg3, arg4);
 
-	if (!is_fda_null(&where.at.pmem_fda))
-		return check_errno(-ENOTSUP, SYS_setxattr);
+	pmemfile_vfd_unref(at);
 
-	return syscall_no_intercept(SYS_setxattr, where.path, arg1, arg2, arg3,
-			arg4);
+	return result;
 }
 
 static long
-hook_mkdirat(long fd, long path_arg, long mode)
+hook_mkdirat(int fd, long path_arg, long mode)
 {
 	long ret;
 	struct resolved_path where;
 
-	struct fd_desc at = fd_fetch(fd);
+	struct vfd_reference at = pmemfile_vfd_at_ref(fd);
 
 	resolve_path(at, (const char *)path_arg, &where, NO_RESOLVE_LAST_SLINK);
 
 	if (where.error_code != 0) {
 		ret = where.error_code;
-	} else if (is_fda_null(&where.at.pmem_fda)) {
+	} else if (where.at_pool == NULL) {
 		ret = syscall_no_intercept(SYS_mkdirat,
-		    where.at.kernel_fd, where.path, mode);
+		    where.at_kernel, where.path, mode);
 	} else {
-		struct pool_description *pool = where.at.pmem_fda.pool;
+		pool_acquire(where.at_pool);
 
-		pool_acquire(pool);
+		long r = wrapper_pmemfile_mkdirat(where.at_pool->pool,
+			where.at_dir, where.path, (mode_t)mode);
 
-		long r = wrapper_pmemfile_mkdirat(pool->pool,
-			where.at.pmem_fda.file, where.path, (mode_t)mode);
-
-		pool_release(pool);
+		pool_release(where.at_pool);
 
 		ret = check_errno(r, SYS_mkdirat);
 	}
 
-	fd_release(&at);
+	pmemfile_vfd_unref(at);
 
 	return ret;
 }
 
 static long
-openat_helper(long fd, struct resolved_path *where, long flags, long mode)
+openat_helper(struct resolved_path *where, long flags, long mode)
 {
-	struct pool_description *pool = where->at.pmem_fda.pool;
+	pool_acquire(where->at_pool);
 
-	pool_acquire(pool);
-
-	PMEMfile *file = pmemfile_openat(pool->pool,
-					where->at.pmem_fda.file,
-					where->path,
+	PMEMfile *file = pmemfile_openat(where->at_pool->pool,
+					where->at_dir, where->path,
 					((int)flags) & ~O_NONBLOCK,
 					(mode_t)mode);
 
-	log_write("pmemfile_openat(%p, %p, \"%s\", 0x%x, %u) = %p",
-					pool->pool,
-					where->at.pmem_fda.file,
+	log_write("pmemfile_openat(%p, %p, \"%s\", 0x%x, %lu) = %p",
+					(void *)where->at_pool->pool,
+					(void *)where->at_dir,
 					where->path,
 					((int)flags) & ~O_NONBLOCK,
-					(mode_t)mode,
+					mode,
 					file);
-	pool_release(pool);
+	pool_release(where->at_pool);
 
-	if (file == NULL) {
-		(void) syscall_no_intercept(SYS_close, fd);
+	if (file == NULL)
 		return check_errno(-errno, SYS_openat);
+
+	int fd = pmemfile_acquire_new_fd(where->path);
+	if (fd < 0)
+		return fd;
+
+	int r = pmemfile_vfd_assign(fd, where->at_pool, file, where->path);
+
+	if (r < 0) {
+		pool_acquire(where->at_pool);
+		pmemfile_close(where->at_pool->pool, file);
+		pool_release(where->at_pool);
+		syscall_no_intercept(SYS_close, fd);
 	}
 
-	util_mutex_lock(&fd_table_mutex);
-
-	__sync_add_and_fetch(&fd_table[fd].ref_count, 1);
-	fd_table[fd].pmemfile.pool = where->at.pmem_fda.pool;
-	fd_table[fd].pmemfile.file = file;
-
-	util_mutex_unlock(&fd_table_mutex);
-
-	return fd;
+	return r;
 }
 
 static long
-hook_openat(long fd_at, long arg0, long flags, long mode)
+hook_openat(int fd_at, long arg0, long flags, long mode)
 {
 	long ret = 0;
 	struct resolved_path where;
@@ -786,38 +594,28 @@ hook_openat(long fd_at, long arg0, long flags, long mode)
 	else
 		follow_last = RESOLVE_LAST_SLINK;
 
-	struct fd_desc at = fd_fetch(fd_at);
+	struct vfd_reference at = pmemfile_vfd_at_ref(fd_at);
 
 	resolve_path(at, path_arg, &where, follow_last);
 
 	if (where.error_code != 0) {
 		/* path resolution failed */
 		ret = where.error_code;
-	} else if (is_fda_null(&where.at.pmem_fda)) {
+	} else if (where.at_pool == NULL) {
 		/* Not pmemfile resident path */
-		ret =  syscall_no_intercept(SYS_openat,
-		    where.at.kernel_fd, where.path, flags, mode);
+		ret = syscall_no_intercept(SYS_openat,
+		    where.at_kernel, where.path, flags, mode);
 	} else {
-		/*
-		 * The fd to represent the pmem resident file
-		 * for the application
-		 */
-		long fd = acquire_new_fd(path_arg);
-
-		if (fd < 0) /* error while trying to allocate a new fd */
-			ret = fd;
-		else
-			ret = openat_helper(fd, &where,
-						flags, mode);
+		ret = openat_helper(&where, flags, mode);
 	}
 
-	fd_release(&at);
+	pmemfile_vfd_unref(at);
 
 	return ret;
 }
 
 static long
-hook_fcntl(struct fd_association *file, int cmd, long arg)
+hook_fcntl(struct vfd_reference *file, int cmd, long arg)
 {
 	assert(!file->pool->suspended);
 	int r = pmemfile_fcntl(file->pool->pool, file->file, cmd, arg);
@@ -826,21 +624,21 @@ hook_fcntl(struct fd_association *file, int cmd, long arg)
 		r = -errno;
 
 	log_write("pmemfile_fcntl(%p, %p, 0x%x, 0x%lx) = %d",
-			(void *)file->pool, (void *)file->file, cmd, arg, r);
+		(void *)file->pool->pool, (void *)file->file, cmd, arg, r);
 
 	return r;
 }
 
 static long
-hook_renameat2(long fd_old, const char *path_old, long fd_new,
+hook_renameat2(int fd_old, const char *path_old, int fd_new,
 		const char *path_new, unsigned flags)
 {
 	long ret;
 	struct resolved_path where_old;
 	struct resolved_path where_new;
 
-	struct fd_desc at_old = fd_fetch(fd_old);
-	struct fd_desc at_new = fd_fetch(fd_new);
+	struct vfd_reference at_old = pmemfile_vfd_at_ref(fd_old);
+	struct vfd_reference at_new = pmemfile_vfd_at_ref(fd_new);
 
 	resolve_path(at_old, path_old, &where_old, NO_RESOLVE_LAST_SLINK);
 	resolve_path(at_new, path_new, &where_new, NO_RESOLVE_LAST_SLINK);
@@ -849,36 +647,35 @@ hook_renameat2(long fd_old, const char *path_old, long fd_new,
 		ret = where_old.error_code;
 	} else if (where_new.error_code != 0) {
 		ret = where_new.error_code;
-	} else if (where_new.at.pmem_fda.pool != where_old.at.pmem_fda.pool) {
+	} else if (where_new.at_pool != where_old.at_pool) {
 		/* cross-pool renames are not supported */
 		ret = -EXDEV;
-	} else if (is_fda_null(&where_new.at.pmem_fda)) {
+	} else if (where_new.at_pool == NULL) {
 		if (flags == 0) {
 			ret = syscall_no_intercept(SYS_renameat,
-			    where_old.at.kernel_fd, where_old.path,
-			    where_new.at.kernel_fd, where_new.path);
+			    where_old.at_kernel, where_old.path,
+			    where_new.at_kernel, where_new.path);
 		} else {
 			ret = syscall_no_intercept(SYS_renameat2,
-			    where_old.at.kernel_fd, where_old.path,
-			    where_new.at.kernel_fd, where_new.path, flags);
+			    where_old.at_kernel, where_old.path,
+			    where_new.at_kernel, where_new.path, flags);
 		}
 	} else {
-		struct pool_description *pool = where_old.at.pmem_fda.pool;
+		pool_acquire(where_old.at_pool);
 
-		pool_acquire(pool);
-
-		int r = wrapper_pmemfile_renameat2(pool->pool,
-				where_old.at.pmem_fda.file, where_old.path,
-				where_new.at.pmem_fda.file, where_new.path,
+		int r = wrapper_pmemfile_renameat2(
+				where_old.at_pool->pool,
+				where_old.at_dir, where_old.path,
+				where_new.at_dir, where_new.path,
 				flags);
 
-		pool_release(pool);
+		pool_release(where_old.at_pool);
 
 		ret = check_errno(r, SYS_renameat2);
 	}
 
-	fd_release(&at_old);
-	fd_release(&at_new);
+	pmemfile_vfd_unref(at_old);
+	pmemfile_vfd_unref(at_new);
 
 	return ret;
 }
@@ -886,101 +683,112 @@ hook_renameat2(long fd_old, const char *path_old, long fd_new,
 static long
 hook_truncate(const char *path, off_t length)
 {
+	long result;
 	struct resolved_path where;
 
-	resolve_path(cwd_desc(), path, &where, RESOLVE_LAST_SLINK);
-	if (where.error_code != 0)
-		return where.error_code;
+	struct vfd_reference at = pmemfile_vfd_at_ref(AT_FDCWD);
 
-	if (is_fda_null(&where.at.pmem_fda))
-		return syscall_no_intercept(SYS_truncate,
-		    where.at.kernel_fd, where.path, length);
+	resolve_path(at, path, &where, RESOLVE_LAST_SLINK);
 
-	struct pool_description *pool = where.at.pmem_fda.pool;
+	if (where.error_code != 0) {
+		result = where.error_code;
+	} else if (where.at_pool == NULL) {
+		/*
+		 * XXX
+		 * This only works as long as where.at_kernel == AT_FDCWD
+		 * or where.path is an absolute path.
+		 */
+		if (where.at_kernel == AT_FDCWD || where.path[0] == '/')
+			result = syscall_no_intercept(SYS_truncate,
+							where.path, length);
+		else
+			result = check_errno(-EIO, SYS_truncate);
+	} else {
+		pool_acquire(where.at_pool);
 
-	pool_acquire(pool);
+		int r = wrapper_pmemfile_truncate(where.at_pool->pool,
+						where.path, length);
 
-	int r = wrapper_pmemfile_truncate(pool->pool, where.path, length);
+		pool_release(where.at_pool);
 
-	pool_release(pool);
+		result = check_errno(r, SYS_truncate);
+	}
 
-	return check_errno(r, SYS_truncate);
+	pmemfile_vfd_unref(at);
+
+	return result;
 }
 
 static long
-hook_symlinkat(const char *target, long fd, const char *linkpath)
+hook_symlinkat(const char *target, int fd, const char *linkpath)
 {
 	long ret;
 	struct resolved_path where;
 
-	struct fd_desc at = fd_fetch(fd);
+	struct vfd_reference at = pmemfile_vfd_at_ref(fd);
 
 	resolve_path(at, linkpath, &where, NO_RESOLVE_LAST_SLINK);
+
 	if (where.error_code != 0) {
 		ret = where.error_code;
-	} else if (is_fda_null(&where.at.pmem_fda)) {
+	} else if (where.at_pool == NULL) {
 		ret = syscall_no_intercept(SYS_symlinkat, target,
-		    where.at.kernel_fd, where.path);
+		    where.at_kernel, where.path);
 	} else {
-		struct pool_description *pool = where.at.pmem_fda.pool;
+		pool_acquire(where.at_pool);
 
-		pool_acquire(pool);
+		int r = wrapper_pmemfile_symlinkat(where.at_pool->pool,
+				target, where.at_dir, where.path);
 
-		int r = wrapper_pmemfile_symlinkat(pool->pool,
-				target,
-				where.at.pmem_fda.file, where.path);
-
-		pool_release(pool);
+		pool_release(where.at_pool);
 
 		ret = check_errno(r, SYS_symlinkat);
 	}
 
-	fd_release(&at);
+	pmemfile_vfd_unref(at);
 
 	return ret;
 }
 
 static long
-hook_fchmodat(long fd, const char *path, mode_t mode)
+hook_fchmodat(int fd, const char *path, mode_t mode)
 {
 	long ret;
 	struct resolved_path where;
 
-	struct fd_desc at = fd_fetch(fd);
+	struct vfd_reference at = pmemfile_vfd_at_ref(fd);
 
 	resolve_path(at, path, &where, RESOLVE_LAST_SLINK);
 
 	if (where.error_code != 0) {
 		ret = where.error_code;
-	} else if (is_fda_null(&where.at.pmem_fda)) {
+	} else if (where.at_pool == NULL) {
 		ret = syscall_no_intercept(SYS_fchmodat,
-		    where.at.kernel_fd, where.path, mode);
+		    where.at_kernel, where.path, mode);
 	} else {
-		struct pool_description *pool = where.at.pmem_fda.pool;
+		pool_acquire(where.at_pool);
 
-		pool_acquire(pool);
+		int r = wrapper_pmemfile_fchmodat(where.at_pool->pool,
+				where.at_dir, where.path, mode, 0);
 
-		int r = wrapper_pmemfile_fchmodat(pool->pool,
-				where.at.pmem_fda.file, where.path, mode, 0);
-
-		pool_release(pool);
+		pool_release(where.at_pool);
 
 		ret = check_errno(r, SYS_fchmodat);
 	}
 
-	fd_release(&at);
+	pmemfile_vfd_unref(at);
 
 	return ret;
 }
 
 static long
-hook_fchownat(long fd, const char *path,
+hook_fchownat(int fd, const char *path,
 				uid_t owner, gid_t group, int flags)
 {
 	long ret;
 	struct resolved_path where;
 
-	struct fd_desc at = fd_fetch(fd);
+	struct vfd_reference at = pmemfile_vfd_at_ref(fd);
 
 	resolve_path(at, path, &where,
 	    (flags & AT_SYMLINK_NOFOLLOW)
@@ -988,72 +796,77 @@ hook_fchownat(long fd, const char *path,
 
 	if (where.error_code != 0) {
 		ret = where.error_code;
-	} else if (is_fda_null(&where.at.pmem_fda)) {
+	} else if (where.at_pool == NULL) {
 		ret = syscall_no_intercept(SYS_fchownat,
-		    where.at.kernel_fd, where.path, owner, group, flags);
+		    where.at_kernel, where.path, owner, group, flags);
 	} else {
-		struct pool_description *pool = where.at.pmem_fda.pool;
+		pool_acquire(where.at_pool);
 
-		pool_acquire(pool);
-
-		int r = wrapper_pmemfile_fchownat(where.at.pmem_fda.pool->pool,
-				where.at.pmem_fda.file, where.path, owner,
+		int r = wrapper_pmemfile_fchownat(where.at_pool->pool,
+				where.at_dir, where.path, owner,
 				group, flags);
 
-		pool_release(pool);
+		pool_release(where.at_pool);
 
 		ret = check_errno(r, SYS_fchownat);
 	}
 
-	fd_release(&at);
+	pmemfile_vfd_unref(at);
 
 	return ret;
 }
 
 static long
-hook_sendfile(long out_fd, long in_fd, off_t *offset, size_t count)
+hook_sendfile(int out_fd, int in_fd, off_t *offset, size_t count)
 {
-	if (is_fd_in_table(out_fd))
-		return check_errno(-ENOTSUP, SYS_sendfile);
+	long ret;
 
-	if (is_fd_in_table(in_fd))
-		return check_errno(-ENOTSUP, SYS_sendfile);
+	struct vfd_reference in = pmemfile_vfd_at_ref(in_fd);
+	struct vfd_reference out = pmemfile_vfd_at_ref(out_fd);
 
-	return syscall_no_intercept(SYS_sendfile, out_fd, in_fd, offset, count);
+	if (in.pool != NULL || out.pool != NULL)
+		ret = check_errno(-ENOTSUP, SYS_sendfile);
+	else
+		ret = syscall_no_intercept(SYS_sendfile,
+						out_fd, in_fd, offset, count);
+
+	pmemfile_vfd_unref(out);
+	pmemfile_vfd_unref(in);
+
+	return ret;
 }
 
 static long
-hook_readlinkat(long fd, const char *path, char *buf, size_t bufsiz)
+hook_readlinkat(int fd, const char *path, char *buf, size_t bufsiz)
 {
 	long ret;
 	struct resolved_path where;
 
-	struct fd_desc at = fd_fetch(fd);
+	struct vfd_reference at = pmemfile_vfd_at_ref(fd);
 
 	resolve_path(at, path, &where, NO_RESOLVE_LAST_SLINK);
 
 	if (where.error_code != 0) {
 		ret = where.error_code;
-	} else if (is_fda_null(&where.at.pmem_fda)) {
+	} else if (where.at_pool == NULL) {
 		ret = syscall_no_intercept(SYS_readlinkat,
-		    where.at.kernel_fd, where.path, buf, bufsiz);
+		    where.at_kernel, where.path, buf, bufsiz);
 	} else {
-		struct pool_description *pool = where.at.pmem_fda.pool;
+		pool_acquire(where.at_pool);
 
-		pool_acquire(pool);
-
-		ssize_t r = wrapper_pmemfile_readlinkat(pool->pool,
-				where.at.pmem_fda.file, where.path, buf,
+		ssize_t r = wrapper_pmemfile_readlinkat(
+				where.at_pool->pool,
+				where.at_dir, where.path, buf,
 				bufsiz);
 
-		pool_release(pool);
+		pool_release(where.at_pool);
 
 		assert(r < INT_MAX);
 
 		ret = check_errno(r, SYS_readlinkat);
 	}
 
-	fd_release(&at);
+	pmemfile_vfd_unref(at);
 
 	return ret;
 }
@@ -1062,194 +875,191 @@ static long
 nosup_syscall_with_path(long syscall_number, const char *path, int resolve_last,
 			long arg1, long arg2, long arg3, long arg4, long arg5)
 {
+	long ret;
 	struct resolved_path where;
 
-	resolve_path(cwd_desc(), path, &where, resolve_last | NO_AT_PATH);
+	struct vfd_reference at = pmemfile_vfd_at_ref(AT_FDCWD);
+
+	resolve_path(at, path, &where, resolve_last | NO_AT_PATH);
 
 	if (where.error_code != 0)
-		return where.error_code;
+		ret = where.error_code;
+	else if (where.at_pool != NULL)
+		ret = check_errno(-ENOTSUP, syscall_number);
+	else
+		ret = syscall_no_intercept(syscall_number, where.path,
+				arg1, arg2, arg3, arg4, arg5);
 
-	if (!is_fda_null(&where.at.pmem_fda))
-		return check_errno(-ENOTSUP, syscall_number);
+	pmemfile_vfd_unref(at);
 
-	return syscall_no_intercept(syscall_number, where.path, arg1, arg2,
-			arg3, arg4, arg5);
+	return ret;
 }
 
 static long
-hook_splice(long fd_in, loff_t *off_in, long fd_out,
+hook_splice(int fd_in, loff_t *off_in, int fd_out,
 			loff_t *off_out, size_t len, unsigned flags)
 {
-	if (is_fd_in_table(fd_out))
-		return check_errno(-ENOTSUP, SYS_splice);
+	/*
+	 * XXX -- this is eerie similar to hook_sendfile and to
+	 * hook_copy_file_range, perhaps these could merged.
+	 */
+	long ret;
 
-	if (is_fd_in_table(fd_in))
-		return check_errno(-ENOTSUP, SYS_splice);
+	struct vfd_reference in = pmemfile_vfd_at_ref(fd_in);
+	struct vfd_reference out = pmemfile_vfd_at_ref(fd_out);
 
-	return syscall_no_intercept(SYS_splice, fd_in, off_in, fd_out, off_out,
-	    len, flags);
+	if (in.pool != NULL || out.pool != NULL)
+		ret = check_errno(-ENOTSUP, SYS_splice);
+	else
+		ret = syscall_no_intercept(SYS_splice,
+				fd_in, off_in, fd_out, off_out, len, flags);
+
+	pmemfile_vfd_unref(out);
+	pmemfile_vfd_unref(in);
+
+	return ret;
 }
 
 static long
-hook_futimesat(long fd, const char *path,
-				const struct timeval times[2])
+hook_futimesat(int fd, const char *path, const struct timeval times[2])
 {
 	long ret;
 	struct resolved_path where;
 
-	struct fd_desc at = fd_fetch(fd);
+	struct vfd_reference at = pmemfile_vfd_at_ref(fd);
 
 	resolve_path(at, (const char *)path, &where, NO_RESOLVE_LAST_SLINK);
 
 	if (where.error_code != 0) {
 		ret = where.error_code;
-	} else if (is_fda_null(&where.at.pmem_fda)) {
+	} else if (where.at_pool == NULL) {
 		ret = syscall_no_intercept(SYS_futimesat,
-				where.at.kernel_fd, where.path, times);
+				where.at_kernel, where.path, times);
 	} else {
-		struct pool_description *pool = where.at.pmem_fda.pool;
+		pool_acquire(where.at_pool);
 
-		pool_acquire(pool);
-
-		int r = pmemfile_futimesat(pool->pool, where.at.pmem_fda.file,
-				where.path, times);
+		int r = pmemfile_futimesat(where.at_pool->pool,
+				where.at_dir, where.path, times);
 
 		if (r != 0)
 			r = -errno;
 
 		if (times) {
 			log_write(
-				"pmemfile_futimesat(%p, %p, \"%s\", [%ld,%ld,%ld,%ld]) = %d",
-			    pool->pool, where.at.pmem_fda.file, where.path,
+			    "pmemfile_futimesat(%p, %p, \"%s\", [%ld,%ld,%ld,%ld]) = %d",
+			    where.at_pool->pool,
+			    where.at_dir, where.path,
 			    times[0].tv_sec, times[0].tv_usec, times[1].tv_sec,
 			    times[1].tv_usec, r);
 		} else {
 			log_write(
-				"pmemfile_futimesat(%p, %p, \"%s\", NULL) = %d",
-			    pool->pool, where.at.pmem_fda.file, where.path, r);
+			    "pmemfile_futimesat(%p, %p, \"%s\", NULL) = %d",
+			    where.at_pool->pool,
+			    where.at_dir, where.path, r);
 		}
 
-		pool_release(pool);
+		pool_release(where.at_pool);
 
 		ret = check_errno(r, SYS_futimesat);
 	}
 
-	fd_release(&at);
+	pmemfile_vfd_unref(at);
 
 	return ret;
 }
 
 static long
-utimensat_helper(int sc, long fd, const char *path,
+utimensat_helper(int sc, struct vfd_reference at, const char *path,
 		const struct timespec times[2], int flags)
 {
-	long ret;
 	struct resolved_path where;
 
-	struct fd_desc at = fd_fetch(fd);
 
 	/*
 	 * Handle non-pmem file descriptor with NULL path earlier. resolve_path
 	 * does not handle empty paths in a way we want here.
 	 */
-	if (is_fda_null(&at.pmem_fda) && path == NULL) {
-		ret = syscall_no_intercept(SYS_utimensat, at.kernel_fd,
+	if (at.pool == NULL && path == NULL) {
+		return syscall_no_intercept(SYS_utimensat, at.kernel_fd,
 				NULL, times, flags);
-		goto end;
 	}
 
 	int follow = (flags & AT_SYMLINK_NOFOLLOW) ?
 			NO_RESOLVE_LAST_SLINK : RESOLVE_LAST_SLINK;
 	resolve_path(at, path, &where, follow);
 
-	if (where.error_code != 0) {
-		ret = where.error_code;
-	} else if (is_fda_null(&where.at.pmem_fda)) {
-		ret = syscall_no_intercept(SYS_utimensat,
-				where.at.kernel_fd, where.path, times, flags);
-	} else {
+	if (where.error_code != 0)
+		return where.error_code;
 
-		int r;
+	if (where.at_pool == NULL)
+		return syscall_no_intercept(SYS_utimensat,
+				where.at_kernel, where.path, times, flags);
 
-		if (path == NULL && flags & ~AT_SYMLINK_NOFOLLOW) {
-			/*
-			 * Currently the only defined flag for utimensat is
-			 * AT_SYMLINK_NOFOLLOW. We have to detect any other flag
-			 * set and return error just in case future kernel
-			 * will accept some new flag.
-			 */
-			ret = -EINVAL;
-		} else if (path == NULL) {
-			struct pool_description *pool = where.at.pmem_fda.pool;
-
-			pool_acquire(pool);
-
-			/*
-			 * Linux nonstandard syscall-level feature. Glibc
-			 * behaves differently, but we have to emulate kernel
-			 * behavior because futimens at glibc level is
-			 * implemented using utimensat with NULL pathname.
-			 * See "C library/ kernel ABI differences"
-			 * section in man utimensat.
-			 */
-			r = pmemfile_futimens(pool->pool,
-					where.at.pmem_fda.file, times);
-
-			if (r != 0)
-				r = -errno;
-
-			if (times) {
-				log_write(
-					"pmemfile_futimens(%p, %p, [%ld,%ld,%ld,%ld]) = %d",
-					pool->pool, where.at.pmem_fda.file,
-					times[0].tv_sec, times[0].tv_nsec,
-					times[1].tv_sec, times[1].tv_nsec, r);
-			} else {
-				log_write(
-					"pmemfile_futimens(%p, %p, NULL) = %d",
-					pool->pool, where.at.pmem_fda.file, r);
-
-			}
-
-			pool_release(pool);
-
-			ret = check_errno(r, sc);
-		} else {
-			struct pool_description *pool = where.at.pmem_fda.pool;
-
-			pool_acquire(pool);
-
-			r = pmemfile_utimensat(pool->pool,
-				where.at.pmem_fda.file, where.path, times,
-				flags);
-
-			if (r != 0)
-				r = -errno;
-
-			if (times) {
-				log_write(
-				    "pmemfile_utimensat(%p, %p, \"%s\", [%ld,%ld,%ld,%ld], %d) = %d",
-				    pool->pool, where.at.pmem_fda.file,
-				    where.path, times[0].tv_sec,
-				    times[0].tv_nsec, times[1].tv_sec,
-				    times[1].tv_nsec, flags, r);
-			} else {
-				log_write(
-				    "pmemfile_utimensat(%p, %p, \"%s\", NULL, %d) = %d",
-				    pool->pool, where.at.pmem_fda.file,
-				    where.path, flags, r);
-			}
-
-			pool_release(pool);
-
-			ret = check_errno(r, sc);
-		}
+	if (path == NULL && flags & ~AT_SYMLINK_NOFOLLOW) {
+		/*
+		 * Currently the only defined flag for utimensat is
+		 * AT_SYMLINK_NOFOLLOW. We have to detect any other flag
+		 * set and return error just in case future kernel
+		 * will accept some new flag.
+		 */
+		return -EINVAL;
 	}
 
-end:
-	fd_release(&at);
+	int r;
 
-	return ret;
+	if (path == NULL) {
+		/*
+		 * Linux nonstandard syscall-level feature. Glibc
+		 * behaves differently, but we have to emulate kernel
+		 * behavior because futimens at glibc level is
+		 * implemented using utimensat with NULL pathname.
+		 * See "C library/ kernel ABI differences"
+		 * section in man utimensat.
+		 */
+		r = pmemfile_futimens(where.at_pool->pool,
+					where.at_dir, times);
+
+		if (r != 0)
+			r = -errno;
+
+		if (times) {
+			log_write(
+			    "pmemfile_futimens(%p, %p, [%ld,%ld,%ld,%ld]) = %d",
+			    where.at_pool->pool, where.at_dir,
+			    times[0].tv_sec, times[0].tv_nsec,
+			    times[1].tv_sec, times[1].tv_nsec, r);
+		} else {
+			log_write("pmemfile_futimens(%p, %p, NULL) = %d",
+			    where.at_pool->pool, where.at_dir, r);
+
+		}
+	} else {
+		pool_acquire(where.at_pool);
+
+		r = pmemfile_utimensat(where.at_pool->pool,
+		    where.at_dir, where.path, times,
+		    flags);
+
+		if (r != 0)
+			r = -errno;
+
+		if (times) {
+			log_write(
+			    "pmemfile_utimensat(%p, %p, \"%s\", [%ld,%ld,%ld,%ld], %d) = %d",
+			    where.at_pool->pool, where.at_dir, where.path,
+			    times[0].tv_sec, times[0].tv_nsec,
+			    times[1].tv_sec, times[1].tv_nsec, flags, r);
+		} else {
+			log_write(
+			    "pmemfile_utimensat(%p, %p, \"%s\", NULL, %d) = %d",
+			    where.at_pool->pool, where.at_dir,
+			    where.path, flags, r);
+		}
+
+		pool_release(where.at_pool);
+	}
+
+	return check_errno(r, sc);
 }
 
 static long
@@ -1265,7 +1075,11 @@ hook_utime(const char *path, const struct utimbuf *times)
 	timespec[1].tv_sec = times->modtime;
 	timespec[1].tv_nsec = 0;
 
-	return utimensat_helper(SYS_utime, AT_FDCWD, path, timespec, 0);
+	struct vfd_reference at = pmemfile_vfd_at_ref(AT_FDCWD);
+	long ret = utimensat_helper(SYS_utime, at, path, timespec, 0);
+	pmemfile_vfd_unref(at);
+
+	return ret;
 }
 
 static long
@@ -1281,169 +1095,214 @@ hook_utimes(const char *path, const struct timeval times[2])
 	timespec[1].tv_sec = times[1].tv_sec;
 	timespec[1].tv_nsec = times[1].tv_usec * 1000;
 
-	return utimensat_helper(SYS_utimes, AT_FDCWD, path, timespec, 0);
-}
-
-static long
-hook_utimensat(long fd, const char *path,
-		const struct timespec times[2], int flags)
-{
-	return utimensat_helper(SYS_utimensat, fd, path, times, flags);
-}
-
-static long
-hook_name_to_handle_at(long fd, const char *path,
-		struct file_handle *handle, int *mount_id, int flags)
-{
-	struct resolved_path where;
-
-	struct fd_desc at = fd_fetch(fd);
-
-	resolve_path(at, path, &where,
-	    (flags & AT_SYMLINK_FOLLOW)
-	    ? RESOLVE_LAST_SLINK : NO_RESOLVE_LAST_SLINK);
-
-	fd_release(&at);
-
-	if (where.error_code != 0)
-		return where.error_code;
-
-	if (where.at.pmem_fda.pool == NULL)
-		return syscall_no_intercept(SYS_name_to_handle_at,
-		    where.at.kernel_fd, where.path, mount_id, flags);
-
-	return check_errno(-ENOTSUP, SYS_name_to_handle_at);
-}
-
-static long
-hook_execveat(long fd, const char *path, char *const argv[],
-		char *const envp[], int flags)
-{
-	struct resolved_path where;
-
-	struct fd_desc at = fd_fetch(fd);
-
-	resolve_path(at, path, &where,
-	    (flags & AT_SYMLINK_NOFOLLOW)
-	    ? NO_RESOLVE_LAST_SLINK : RESOLVE_LAST_SLINK);
-
-	fd_release(&at);
-
-	if (where.error_code != 0)
-		return where.error_code;
-
-	if (!is_fda_null(&where.at.pmem_fda))
-		/* The expectation is that pmemfile will never support this. */
-		return check_errno(-ENOTSUP, SYS_execveat);
-
-	unsigned env_idx = 0;
-	char **new_envp = NULL;
-	char *cwd = NULL;
-	char *pmemfile_cd = NULL;
-	long ret;
-
-	if (process_switching && cwd_pool) {
-		unsigned envs = 0;
-		while (envp[envs] != 0)
-			envs++;
-
-		new_envp = malloc((envs + 2) * sizeof(char *));
-		if (!new_envp)
-			return -errno;
-
-		/* Copy all environment variables, but skip PMEMFILE_CD. */
-		for (unsigned i = 0; i < envs; ++i) {
-			if (strncmp(envp[i], "PMEMFILE_CD=", 12) == 0)
-				continue;
-			new_envp[env_idx++] = envp[i];
-		}
-
-		pool_acquire(cwd_pool);
-		cwd = pmemfile_getcwd(cwd_pool->pool, NULL, 0);
-		pool_release(cwd_pool);
-		if (!cwd) {
-			ret = -errno;
-			goto end;
-		}
-
-		if (asprintf(&pmemfile_cd, "PMEMFILE_CD=%s/%s",
-				cwd_pool->mount_point, cwd) == -1) {
-			ret = -errno;
-			goto end;
-		}
-		new_envp[env_idx++] = pmemfile_cd;
-		new_envp[env_idx++] = NULL;
-		envp = new_envp;
-	}
-
-	ret = syscall_no_intercept(SYS_execveat, where.at.kernel_fd,
-			where.path, argv, envp, flags);
-
-end:
-	if (process_switching && cwd_pool) {
-		free(pmemfile_cd);
-		free(new_envp);
-		free(cwd);
-	}
+	struct vfd_reference at = pmemfile_vfd_at_ref(AT_FDCWD);
+	long ret = utimensat_helper(SYS_utimes, at, path, timespec, 0);
+	pmemfile_vfd_unref(at);
 
 	return ret;
 }
 
 static long
-hook_copy_file_range(long fd_in, loff_t *off_in, long fd_out,
-			loff_t *off_out, size_t len, unsigned flags)
+hook_utimensat(int fd, const char *path,
+		const struct timespec times[2], int flags)
 {
-	if (is_fd_in_table(fd_out))
-		return check_errno(-ENOTSUP, SYS_copy_file_range);
+	struct vfd_reference at = pmemfile_vfd_at_ref(fd);
+	long ret = utimensat_helper(SYS_utimensat, at, path, times, flags);
+	pmemfile_vfd_unref(at);
 
-	if (is_fd_in_table(fd_in))
-		return check_errno(-ENOTSUP, SYS_copy_file_range);
-
-	return syscall_no_intercept(SYS_copy_file_range,
-	    fd_in, off_in, fd_out, off_out, len, flags);
+	return ret;
 }
 
 static long
-hook_mmap(long arg0, long arg1, long arg2,
-		long arg3, long fd, long arg5)
-{
-	if (is_fd_in_table(fd))
-		return check_errno(-ENOTSUP, SYS_mmap);
-
-	return syscall_no_intercept(SYS_mmap,
-	    arg0, arg1, arg2, arg3, fd, arg5);
-}
-
-static long
-hook_mknodat(long fd, const char *path, mode_t mode, dev_t dev)
+hook_name_to_handle_at(int fd, const char *path,
+		struct file_handle *handle, int *mount_id, int flags)
 {
 	long ret;
 	struct resolved_path where;
 
-	struct fd_desc at = fd_fetch(fd);
+	struct vfd_reference at = pmemfile_vfd_at_ref(fd);
+
+	resolve_path(at, path, &where,
+	    (flags & AT_SYMLINK_FOLLOW)
+	    ? RESOLVE_LAST_SLINK : NO_RESOLVE_LAST_SLINK);
+
+	if (where.error_code != 0)
+		ret = where.error_code;
+	else if (where.at_pool == NULL)
+		ret = syscall_no_intercept(SYS_name_to_handle_at,
+		    where.at_kernel, where.path, mount_id, flags);
+	else
+		ret = check_errno(-ENOTSUP, SYS_name_to_handle_at);
+
+	pmemfile_vfd_unref(at);
+
+	return ret;
+}
+
+struct execvat_desc {
+	char **new_envp;
+	char *pmemfile_cd;
+	char *const *argv;
+	char *const *envp;
+	char *cwd;
+	int flags;
+};
+
+static long
+hook_execveat_vfdref(struct pool_description *cwd_pool,
+			struct execvat_desc *desc)
+{
+	static const char prefix[] = "PMEMFILE_CD=";
+
+	unsigned env_idx = 0;
+
+	unsigned envs = 0;
+	while (desc->envp[envs] != NULL)
+		envs++;
+
+	desc->new_envp = malloc((envs + 2) * sizeof(char *));
+	if (!desc->new_envp)
+		return -errno;
+
+	/* Copy all environment variables, but skip PMEMFILE_CD. */
+	for (unsigned i = 0; i < envs; ++i) {
+		if (strncmp(desc->envp[i], prefix, strlen(prefix)) == 0)
+			continue;
+		desc->new_envp[env_idx++] = desc->envp[i];
+	}
+
+	pool_acquire(cwd_pool);
+	desc->cwd = pmemfile_getcwd(cwd_pool->pool, NULL, 0);
+	pool_release(cwd_pool);
+
+	if (!desc->cwd)
+		return -errno;
+
+	if (asprintf(&desc->pmemfile_cd, "%s%s/%s",
+			prefix, cwd_pool->mount_point, desc->cwd) == -1)
+		return -errno;
+
+	desc->new_envp[env_idx++] = desc->pmemfile_cd;
+	desc->new_envp[env_idx++] = NULL;
+	desc->envp = desc->new_envp;
+
+	return 0;
+}
+
+static long
+hook_execveat(int fd, const char *path, char *const argv[],
+		char *const envp[], int flags)
+{
+	long ret = 0;
+
+	struct vfd_reference at = pmemfile_vfd_at_ref(fd);
+	struct resolved_path where;
+
+	resolve_path(at, path, &where,
+	    (flags & AT_SYMLINK_NOFOLLOW)
+	    ? NO_RESOLVE_LAST_SLINK : RESOLVE_LAST_SLINK);
+
+	if (where.error_code != 0) {
+		ret = where.error_code;
+	} else if (where.at_pool != NULL) {
+		/* The expectation is that pmemfile will never support this. */
+		ret = check_errno(-ENOTSUP, SYS_execveat);
+	} else {
+		struct execvat_desc desc = {
+		    .argv = argv, .envp = envp, .flags = flags, };
+
+		util_mutex_lock(&cwd_mutex);
+		struct vfd_reference cwd = pmemfile_vfd_at_ref(AT_FDCWD);
+
+		if (process_switching && cwd.pool != NULL)
+			ret = hook_execveat_vfdref(cwd.pool, &desc);
+
+		pmemfile_vfd_unref(cwd);
+		util_mutex_unlock(&cwd_mutex);
+
+		if (ret == 0)
+			ret = syscall_no_intercept(SYS_execveat,
+				where.at_kernel, where.path,
+				desc.argv, desc.envp, desc.flags);
+
+		free(desc.pmemfile_cd);
+		free(desc.new_envp);
+		free(desc.cwd);
+	}
+
+	pmemfile_vfd_unref(at);
+
+	return ret;
+}
+
+static long
+hook_copy_file_range(int fd_in, loff_t *off_in, int fd_out,
+			loff_t *off_out, size_t len, unsigned flags)
+{
+	long ret;
+
+	struct vfd_reference in = pmemfile_vfd_at_ref(fd_in);
+	struct vfd_reference out = pmemfile_vfd_at_ref(fd_out);
+
+	if (in.pool != NULL || out.pool != NULL)
+		ret = check_errno(-ENOTSUP, SYS_copy_file_range);
+	else
+		ret = syscall_no_intercept(SYS_copy_file_range,
+				fd_in, off_in, fd_out, off_out, len, flags);
+
+	pmemfile_vfd_unref(out);
+	pmemfile_vfd_unref(in);
+
+	return ret;
+}
+
+static long
+hook_mmap(long arg0, long arg1, long arg2,
+		long arg3, int fd, long arg5)
+{
+	long ret;
+
+	struct vfd_reference file = pmemfile_vfd_ref(fd);
+
+	if (file.pool != NULL)
+		ret = check_errno(-ENOTSUP, SYS_mmap);
+	else
+		ret = syscall_no_intercept(SYS_mmap,
+			arg0, arg1, arg2, arg3, file.kernel_fd, arg5);
+
+	pmemfile_vfd_unref(file);
+
+	return ret;
+}
+
+static long
+hook_mknodat(int fd, const char *path, mode_t mode, dev_t dev)
+{
+	long ret;
+	struct resolved_path where;
+
+	struct vfd_reference at = pmemfile_vfd_at_ref(fd);
 
 	resolve_path(at, path, &where, NO_RESOLVE_LAST_SLINK);
 
 	if (where.error_code != 0) {
 		ret = where.error_code;
-	} else if (is_fda_null(&where.at.pmem_fda)) {
+	} else if (where.at_pool == NULL) {
 		ret = syscall_no_intercept(SYS_mknodat,
-		    where.at.kernel_fd, where.path, mode, dev);
+		    where.at_kernel, where.path, mode, dev);
 	} else {
-		struct pool_description *pool = where.at.pmem_fda.pool;
+		pool_acquire(where.at_pool);
 
-		pool_acquire(pool);
-
-		long r = wrapper_pmemfile_mknodat(pool->pool,
-		    where.at.pmem_fda.file, where.path, (mode_t) mode,
+		long r = wrapper_pmemfile_mknodat(where.at_pool->pool,
+		    where.at_dir, where.path, (mode_t) mode,
 		    (dev_t) dev);
 
-		pool_release(pool);
+		pool_release(where.at_pool);
 
 		ret = check_errno(r, SYS_mknodat);
 	}
 
-	fd_release(&at);
+	pmemfile_vfd_unref(at);
 
 	return ret;
 }
@@ -1686,33 +1545,39 @@ hook_bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
 
 	const struct sockaddr_un *uaddr = (struct sockaddr_un *)addr;
 
+	long ret;
 	struct resolved_path where;
 
-	struct fd_desc at = cwd_desc();
+	struct vfd_reference at = pmemfile_vfd_at_ref(AT_FDCWD);
 
 	resolve_path(at, uaddr->sun_path, &where,
 			NO_RESOLVE_LAST_SLINK | NO_AT_PATH);
 
-	if (where.error_code != 0)
-		return where.error_code;
+	if (where.error_code != 0) {
+		ret = where.error_code;
+	} else if (where.at_pool != NULL) {
+		ret = check_errno(-ENOTSUP, SYS_bind);
+	} else {
+		struct sockaddr_un tmp_uaddr;
 
-	if (!is_fda_null(&where.at.pmem_fda))
-		return check_errno(-ENOTSUP, SYS_bind);
+		tmp_uaddr.sun_family = AF_UNIX;
 
-	struct sockaddr_un tmp_uaddr;
+		size_t len = strlen(where.path);
 
-	tmp_uaddr.sun_family = AF_UNIX;
+		if (len >= sizeof(tmp_uaddr.sun_path)) {
+			ret = -ENAMETOOLONG;
+		} else {
+			strncpy(tmp_uaddr.sun_path, where.path, len);
+			tmp_uaddr.sun_path[len] = 0;
 
-	size_t len = strlen(where.path);
+			ret = syscall_no_intercept(SYS_bind, sockfd, &tmp_uaddr,
+					sizeof(tmp_uaddr));
+		}
+	}
 
-	if (len >= sizeof(tmp_uaddr.sun_path))
-		return -ENAMETOOLONG;
+	pmemfile_vfd_unref(at);
 
-	strncpy(tmp_uaddr.sun_path, where.path, len);
-	tmp_uaddr.sun_path[len] = 0;
-
-	return syscall_no_intercept(SYS_bind, sockfd, &tmp_uaddr,
-			sizeof(tmp_uaddr));
+	return ret;
 }
 
 static long
@@ -1733,18 +1598,18 @@ dispatch_syscall(long syscall_number,
 			O_WRONLY | O_CREAT | O_TRUNC, arg1);
 
 	case SYS_openat:
-		return hook_openat(arg0, arg1, arg2, arg3);
+		return hook_openat((int)arg0, arg1, arg2, arg3);
 
 	case SYS_rename:
 		return hook_renameat2(AT_FDCWD, (const char *)arg0,
 			AT_FDCWD, (const char *)arg1, 0);
 
 	case SYS_renameat:
-		return hook_renameat2(arg0, (const char *)arg1, arg2,
+		return hook_renameat2((int)arg0, (const char *)arg1, (int)arg2,
 			(const char *)arg3, 0);
 
 	case SYS_renameat2:
-		return hook_renameat2(arg0, (const char *)arg1, arg2,
+		return hook_renameat2((int)arg0, (const char *)arg1, (int)arg2,
 			(const char *)arg3, (unsigned)arg4);
 
 	case SYS_link:
@@ -1752,14 +1617,14 @@ dispatch_syscall(long syscall_number,
 		return hook_linkat(AT_FDCWD, arg0, AT_FDCWD, arg1, 0);
 
 	case SYS_linkat:
-		return hook_linkat(arg0, arg1, arg2, arg3, arg4);
+		return hook_linkat((int)arg0, arg1, (int)arg2, arg3, arg4);
 
 	case SYS_unlink:
 		/* Use pmemfile_unlinkat to implement unlink */
 		return hook_unlinkat(AT_FDCWD, arg0, 0);
 
 	case SYS_unlinkat:
-		return hook_unlinkat(arg0, arg1, arg2);
+		return hook_unlinkat((int)arg0, arg1, arg2);
 
 	case SYS_rmdir:
 		/* Use pmemfile_unlinkat to implement rmdir */
@@ -1770,14 +1635,14 @@ dispatch_syscall(long syscall_number,
 		return hook_mkdirat(AT_FDCWD, arg0, arg1);
 
 	case SYS_mkdirat:
-		return hook_mkdirat(arg0, arg1, arg2);
+		return hook_mkdirat((int)arg0, arg1, arg2);
 
 	case SYS_access:
 		/* Use pmemfile_faccessat to implement access */
 		return hook_faccessat(AT_FDCWD, arg0, 0);
 
 	case SYS_faccessat:
-		return hook_faccessat(arg0, arg1, arg2);
+		return hook_faccessat((int)arg0, arg1, arg2);
 
 	/*
 	 * The newfstatat syscall implements both stat and lstat.
@@ -1795,13 +1660,13 @@ dispatch_syscall(long syscall_number,
 		    AT_SYMLINK_NOFOLLOW);
 
 	case SYS_newfstatat:
-		return hook_newfstatat(arg0, arg1, arg2, arg3);
+		return hook_newfstatat((int)arg0, arg1, arg2, arg3);
 
 	case SYS_close:
-		return hook_close(arg0);
+		return pmemfile_vfd_close((int)arg0);
 
 	case SYS_mmap:
-		return hook_mmap(arg0, arg1, arg2, arg3, arg4, arg5);
+		return hook_mmap(arg0, arg1, arg2, arg3, (int)arg4, arg5);
 
 	/*
 	 * NOP implementations for the xattr family. None of these
@@ -1832,7 +1697,7 @@ dispatch_syscall(long syscall_number,
 			AT_FDCWD, (const char *)arg1);
 
 	case SYS_symlinkat:
-		return hook_symlinkat((const char *)arg0, arg1,
+		return hook_symlinkat((const char *)arg0, (int)arg1,
 			(const char *)arg2);
 
 	case SYS_chmod:
@@ -1840,7 +1705,7 @@ dispatch_syscall(long syscall_number,
 			(mode_t)arg1);
 
 	case SYS_fchmodat:
-		return hook_fchmodat(arg0, (const char *)arg1,
+		return hook_fchmodat((int)arg0, (const char *)arg1,
 			(mode_t)arg2);
 
 	case SYS_chown:
@@ -1852,18 +1717,19 @@ dispatch_syscall(long syscall_number,
 			(uid_t)arg1, (gid_t)arg2, AT_SYMLINK_NOFOLLOW);
 
 	case SYS_fchownat:
-		return hook_fchownat(arg0, (const char *)arg1,
+		return hook_fchownat((int)arg0, (const char *)arg1,
 			(uid_t)arg2, (gid_t)arg3, (int)arg4);
 
 	case SYS_sendfile:
-		return hook_sendfile(arg0, arg1, (off_t *)arg2, (size_t)arg3);
+		return hook_sendfile((int)arg0, (int)arg1,
+					(off_t *)arg2, (size_t)arg3);
 
 	case SYS_mknod:
 		return hook_mknodat(AT_FDCWD, (const char *)arg0,
 				(mode_t)arg1, (dev_t)arg2);
 
 	case SYS_mknodat:
-		return hook_mknodat(arg0, (const char *)arg1,
+		return hook_mknodat((int)arg0, (const char *)arg1,
 				(mode_t)arg2, (dev_t)arg3);
 
 	case SYS_setfsuid:
@@ -1921,15 +1787,15 @@ dispatch_syscall(long syscall_number,
 		    (char *)arg1, (size_t)arg2);
 
 	case SYS_readlinkat:
-		return hook_readlinkat(arg0, (const char *)arg1,
+		return hook_readlinkat((int)arg0, (const char *)arg1,
 		    (char *)arg2, (size_t)arg3);
 
 	case SYS_splice:
-		return hook_splice(arg0, (loff_t *)arg1, arg2,
+		return hook_splice((int)arg0, (loff_t *)arg1, (int)arg2,
 			(loff_t *)arg3, (size_t)arg4, (unsigned)arg5);
 
 	case SYS_futimesat:
-		return hook_futimesat(arg0, (const char *)arg1,
+		return hook_futimesat((int)arg0, (const char *)arg1,
 			(const struct timeval *)arg2);
 
 	case SYS_utime:
@@ -1941,11 +1807,11 @@ dispatch_syscall(long syscall_number,
 				(const struct timeval *)arg1);
 
 	case SYS_utimensat:
-		return hook_utimensat(arg0, (const char *)arg1,
+		return hook_utimensat((int)arg0, (const char *)arg1,
 				(const struct timespec *)arg2, (int)arg3);
 
 	case SYS_name_to_handle_at:
-		return hook_name_to_handle_at(arg0, (const char *)arg1,
+		return hook_name_to_handle_at((int)arg0, (const char *)arg1,
 			(struct file_handle *)arg2, (int *)arg3, (int)arg4);
 
 	case SYS_execve:
@@ -1953,12 +1819,12 @@ dispatch_syscall(long syscall_number,
 		    (char *const *)arg1, (char *const *)arg2, 0);
 
 	case SYS_execveat:
-		return hook_execveat(arg0, (const char *)arg1,
+		return hook_execveat((int)arg0, (const char *)arg1,
 			(char *const *)arg2, (char *const *)arg3, (int)arg4);
 
 	case SYS_copy_file_range:
-		return hook_copy_file_range(arg0, (loff_t *)arg1,
-		    arg2, (loff_t *)arg3, (size_t)arg4, (unsigned)arg5);
+		return hook_copy_file_range((int)arg0, (loff_t *)arg1,
+		    (int)arg2, (loff_t *)arg3, (size_t)arg4, (unsigned)arg5);
 
 	case SYS_bind:
 		return hook_bind((int)arg0, (const struct sockaddr *)arg1,
@@ -1974,7 +1840,7 @@ dispatch_syscall(long syscall_number,
 
 static long
 dispatch_syscall_fd_first(long syscall_number,
-			struct fd_association *arg0, long arg1,
+			struct vfd_reference *arg0, long arg1,
 			long arg2, long arg3,
 			long arg4, long arg5)
 {
@@ -2194,14 +2060,14 @@ hook(long syscall_number,
 	}
 
 	if (syscall_number == SYS_fchdir) {
-		*syscall_return_value = hook_fchdir(arg0);
+		util_mutex_unlock(&cwd_mutex);
+		*syscall_return_value = pmemfile_vfd_fchdir((int)arg0);
+		util_mutex_unlock(&cwd_mutex);
 		return HOOKED;
 	}
 
 	if (syscall_number == SYS_getcwd) {
-		util_rwlock_rdlock(&pmem_cwd_lock);
 		*syscall_return_value = hook_getcwd((char *)arg0, (size_t)arg1);
-		util_rwlock_unlock(&pmem_cwd_lock);
 		return HOOKED;
 	}
 
@@ -2213,15 +2079,12 @@ hook(long syscall_number,
 
 	int is_hooked;
 
-	if (filter_entry.cwd_rlock)
-		util_rwlock_rdlock(&pmem_cwd_lock);
-
 	is_hooked = HOOKED;
 
 	if (filter_entry.fd_first_arg) {
-		struct fd_association file = fd_ref(arg0);
+		struct vfd_reference file = pmemfile_vfd_ref((int)arg0);
 
-		if (is_fda_null(&file)) {
+		if (file.pool == NULL) {
 			is_hooked = NOT_HOOKED;
 		} else if (filter_entry.returns_zero) {
 			*syscall_return_value = 0;
@@ -2241,16 +2104,11 @@ hook(long syscall_number,
 			pool_release(file.pool);
 		}
 
-		if (!is_fda_null(&file))
-			fd_unref(arg0, &file);
-	}
-	else
+		pmemfile_vfd_unref(file);
+	} else {
 		*syscall_return_value = dispatch_syscall(syscall_number,
 			arg0, arg1, arg2, arg3, arg4, arg5);
-
-
-	if (filter_entry.cwd_rlock)
-		util_rwlock_unlock(&pmem_cwd_lock);
+	}
 
 	return is_hooked;
 }
@@ -2429,6 +2287,37 @@ stat_cwd(struct stat *kernel_cwd_stat)
 	}
 }
 
+/*
+ * open_pool_at_startup - open a pool at startup, if cwd points to it
+ *
+ * If the current working directory is a mount point, then
+ * the corresponding pmemfile pool must opened at startup.
+ * Normally, a pool is only opened the first time it is
+ * accessed, but without doing this, the first access would
+ * never be noticed.
+ */
+static void
+open_pool_at_startup(struct pool_description *pool_desc)
+{
+	open_new_pool(pool_desc);
+
+	if (pool_desc->pool == NULL) {
+		exit_with_msg(PMEMFILE_PRELOAD_EXIT_POOL_OPEN_FAILED,
+				"!opening pmemfile_pool");
+	}
+
+	PMEMfile *file = pmemfile_open(pool_desc->pool, ".",
+				O_DIRECTORY | O_PATH | O_NOCTTY);
+
+	if (file == NULL)
+		exit_with_msg(PMEMFILE_PRELOAD_EXIT_POOL_OPEN_FAILED,
+				"!opening cwd pmemfile_pool");
+
+	if (pmemfile_vfd_chdir_pf(pool_desc, file) != 0)
+		exit_with_msg(PMEMFILE_PRELOAD_EXIT_POOL_OPEN_FAILED,
+				"!chdir into pmemfile_pool");
+}
+
 static void
 init_pool(struct pool_description *pool_desc, struct stat *kernel_cwd_stat)
 {
@@ -2449,14 +2338,8 @@ init_pool(struct pool_description *pool_desc, struct stat *kernel_cwd_stat)
 	 * accessed, but without doing this, the first access would
 	 * never be noticed.
 	 */
-	if (same_inode(&pool_desc->stat, kernel_cwd_stat)) {
-		open_new_pool(pool_desc);
-		if (pool_desc->pool == NULL) {
-			exit_with_msg(PMEMFILE_PRELOAD_EXIT_POOL_OPEN_FAILED,
-				"!opening pmemfile_pool");
-		}
-		cwd_pool = pool_desc;
-	}
+	if (same_inode(&pool_desc->stat, kernel_cwd_stat))
+		open_pool_at_startup(pool_desc);
 }
 
 static void
@@ -2644,7 +2527,7 @@ pmemfile_preload_constructor(void)
 	if (!syscall_hook_in_process_allowed())
 		return;
 
-	check_memfd_syscall();
+	pmemfile_vfd_table_init();
 
 	log_init(getenv("PMEMFILE_PRELOAD_LOG"),
 			getenv("PMEMFILE_PRELOAD_LOG_TRUNC"));

--- a/src/libpmemfile/preload.h
+++ b/src/libpmemfile/preload.h
@@ -41,6 +41,8 @@
 
 #include "compiler_utils.h"
 
+#include "vfd_table.h"
+
 struct pmemfilepool;
 struct pmemfile_file;
 
@@ -104,37 +106,18 @@ same_inode(const struct stat *st1, const struct stat *st2)
 	return st1->st_ino == st2->st_ino && st1->st_dev == st2->st_dev;
 }
 
-/*
- * The array fd_table is used to look up file descriptors, and find a pool, and
- * PMEM file open in that pool. When the 'file' member is NULL, the fd is
- * not used ( but might still be in the fd_pool ).
- */
-struct fd_association {
-	struct pool_description *pool;
-	struct pmemfile_file *file;
-};
-
-static inline bool
-is_fda_null(const struct fd_association *fda)
-{
-	return fda->pool == NULL;
-}
-
-struct fd_desc {
-	long kernel_fd;
-	struct fd_association pmem_fda;
-};
-
 struct resolved_path {
 	long error_code;
 
-	struct fd_desc at;
+	long at_kernel;
+	struct pool_description *at_pool;
+	struct pmemfile_file *at_dir;
 
 	char path[PATH_MAX];
 	size_t path_len;
 };
 
-void resolve_path(struct fd_desc at,
+void resolve_path(struct vfd_reference at,
 			const char *path,
 			struct resolved_path *result,
 			int flags);

--- a/src/libpmemfile/syscall_early_filter.c
+++ b/src/libpmemfile/syscall_early_filter.c
@@ -45,26 +45,21 @@
 static struct syscall_early_filter_entry filter_table[] = {
 	[SYS_access] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_chmod] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_chown] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_close] = {
 		.must_handle = true,
 	},
 	[SYS_creat] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_faccessat] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_fadvise64] = {
 		.must_handle = true,
@@ -77,7 +72,6 @@ static struct syscall_early_filter_entry filter_table[] = {
 	},
 	[SYS_fchmodat] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_fchmod] = {
 		.must_handle = true,
@@ -85,7 +79,6 @@ static struct syscall_early_filter_entry filter_table[] = {
 	},
 	[SYS_fchownat] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_fchown] = {
 		.must_handle = true,
@@ -129,7 +122,6 @@ static struct syscall_early_filter_entry filter_table[] = {
 	},
 	[SYS_futimesat] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_getdents64] = {
 		.must_handle = true,
@@ -141,23 +133,18 @@ static struct syscall_early_filter_entry filter_table[] = {
 	},
 	[SYS_getxattr] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_lchown] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_lgetxattr] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_linkat] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_link] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_lseek] = {
 		.must_handle = true,
@@ -165,39 +152,30 @@ static struct syscall_early_filter_entry filter_table[] = {
 	},
 	[SYS_lsetxattr] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_lstat] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_mkdirat] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_mkdir] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_mknod] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_mknodat] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_newfstatat] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_openat] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_open] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_pread64] = {
 		.must_handle = true,
@@ -229,11 +207,9 @@ static struct syscall_early_filter_entry filter_table[] = {
 	},
 	[SYS_readlinkat] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_readlink] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_readv] = {
 		.must_handle = true,
@@ -241,23 +217,18 @@ static struct syscall_early_filter_entry filter_table[] = {
 	},
 	[SYS_renameat2] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_renameat] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_rename] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_rmdir] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_setxattr] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_setfsuid] = {
 		.must_handle = true,
@@ -288,48 +259,38 @@ static struct syscall_early_filter_entry filter_table[] = {
 	},
 	[SYS_stat] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_symlinkat] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_symlink] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_syncfs] = {
 		.must_handle = true,
 		.fd_first_arg = true,
-		.cwd_rlock = true,
 		.returns_zero = true,
 	},
 	[SYS_truncate] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_umask] = {
 		.must_handle = true,
 	},
 	[SYS_unlinkat] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_unlink] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_utime] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_utimensat] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_utimes] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_write] = {
 		.must_handle = true,
@@ -343,11 +304,9 @@ static struct syscall_early_filter_entry filter_table[] = {
 	/* Syscalls not handled yet */
 	[SYS_bind] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_chroot] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_copy_file_range] = {
 		.must_handle = true,
@@ -369,11 +328,9 @@ static struct syscall_early_filter_entry filter_table[] = {
 	},
 	[SYS_execveat] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_execve] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_flistxattr] = {
 		.must_handle = true,
@@ -387,15 +344,12 @@ static struct syscall_early_filter_entry filter_table[] = {
 	},
 	[SYS_listxattr] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_llistxattr] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_lremovexattr] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_mmap] = {
 		.must_handle = true,
@@ -410,7 +364,6 @@ static struct syscall_early_filter_entry filter_table[] = {
 	},
 	[SYS_removexattr] = {
 		.must_handle = true,
-		.cwd_rlock = true,
 	},
 	[SYS_sendfile] = {
 		.must_handle = true,

--- a/src/libpmemfile/syscall_early_filter.c
+++ b/src/libpmemfile/syscall_early_filter.c
@@ -313,8 +313,6 @@ static struct syscall_early_filter_entry filter_table[] = {
 	},
 	[SYS_dup2] = {
 		.must_handle = true,
-		.fd_first_arg = true,
-		.returns_ENOTSUP = true,
 	},
 	[SYS_dup3] = {
 		.must_handle = true,
@@ -323,8 +321,6 @@ static struct syscall_early_filter_entry filter_table[] = {
 	},
 	[SYS_dup] = {
 		.must_handle = true,
-		.fd_first_arg = true,
-		.returns_ENOTSUP = true,
 	},
 	[SYS_execveat] = {
 		.must_handle = true,

--- a/src/libpmemfile/syscall_early_filter.h
+++ b/src/libpmemfile/syscall_early_filter.h
@@ -57,19 +57,6 @@ struct syscall_early_filter_entry {
 	bool must_handle;
 
 	/*
-	 * In the case some syscalls, an argument containing a path must
-	 * be parsed. The cwd_rlock flag signals the need for locking (for
-	 * reading) the reference to the current working directory for reading,
-	 * which should not be modified while doing a path resolution.
-	 *
-	 * This of course isn't really needed when parsing an absolute path,
-	 * as the CWD is not relevant in that case.
-	 *
-	 * XXX lock the CWD only while parsing a relative path.
-	 */
-	bool cwd_rlock;
-
-	/*
 	 * The fd_first_arg flag marks syscalls, which accept a file descriptor
 	 * as their first argument. This allows libpmemfile to easily isolate
 	 * the process of checking the first argument, and making a decision

--- a/src/libpmemfile/vfd_table.c
+++ b/src/libpmemfile/vfd_table.c
@@ -1,0 +1,656 @@
+/*
+ * Copyright 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "vfd_table.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <fcntl.h>
+#include <syscall.h>
+
+#include <libsyscall_intercept_hook_point.h>
+#include <libpmemfile-posix.h>
+
+#include "sys_util.h"
+#include "preload.h"
+
+struct vfile_description {
+	struct pool_description *pool;
+	PMEMfile *file;
+	int kernel_cwd_fd;
+	bool is_special_cwd_desc;
+	int ref_count;
+};
+
+static void
+vf_ref_count_inc(struct vfile_description *entry)
+{
+	__atomic_add_fetch(&entry->ref_count, 1, __ATOMIC_ACQ_REL);
+}
+
+static void
+ref_entry(struct vfile_description *entry)
+{
+	if (entry != NULL)
+		vf_ref_count_inc(entry);
+}
+
+static int
+vf_ref_count_dec_and_fetch(struct vfile_description *entry)
+{
+	return __atomic_sub_fetch(&entry->ref_count, 1, __ATOMIC_ACQ_REL);
+}
+
+static struct vfile_description *cwd_entry;
+static struct vfile_description *vfd_table[0x8000];
+
+static pthread_mutex_t vfd_table_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+/*
+ * The fetch_free_file_slot and mark_as_free_file_slot functions can be
+ * used to allocate, and deallocate vfile_description entries.
+ *
+ */
+static struct vfile_description *free_vfile_slots[ARRAY_SIZE(vfd_table)];
+static unsigned free_slot_count;
+static pthread_mutex_t free_vfile_slot_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+static void
+mark_as_free_file_slot(struct vfile_description *entry)
+{
+	util_mutex_lock(&free_vfile_slot_mutex);
+
+	assert(entry->ref_count == 0);
+
+	free_vfile_slots[free_slot_count++] = entry;
+
+	util_mutex_unlock(&free_vfile_slot_mutex);
+}
+
+static struct vfile_description *
+fetch_free_file_slot(void)
+{
+	struct vfile_description *entry;
+
+	util_mutex_lock(&free_vfile_slot_mutex);
+
+	if (free_slot_count == 0)
+		entry = NULL;
+	else
+		entry = free_vfile_slots[--free_slot_count];
+
+	util_mutex_unlock(&free_vfile_slot_mutex);
+
+	return entry;
+}
+
+/*
+ * setup_free_slots -- fills the free list with pointers to vfile_description
+ * entries, allocated in BSS.
+ * Must be called during startup.
+ */
+static void
+setup_free_slots(void)
+{
+	static struct vfile_description store[ARRAY_SIZE(free_vfile_slots) - 1];
+
+	for (unsigned i = 0; i < ARRAY_SIZE(store); ++i)
+		mark_as_free_file_slot(store + i);
+}
+
+static struct vfd_reference
+pmemfile_ref_vfd_under_mutex(int vfd)
+{
+	struct vfile_description *entry = vfd_table[vfd];
+
+	if (entry == NULL) {
+		/*
+		 * Return a vfd_reference with the field called internal
+		 * set to NULL.
+		 */
+		return (struct vfd_reference) {.kernel_fd = vfd, };
+	}
+
+	vf_ref_count_inc(entry);
+
+	return (struct vfd_reference) {
+	    .pool = entry->pool, .file = entry->file, .internal = entry, };
+}
+
+/*
+ * is_in_vfd_table_range -- check if the number can be used as an index
+ * for the vfd_table array.
+ */
+static bool
+is_in_vfd_table_range(int number)
+{
+	return (number >= 0) && (number < (int)ARRAY_SIZE(vfd_table));
+}
+
+/*
+ * can_be_in_vfd_table -- check if the vfd can considered to be one
+ * not handled by pmemfile, i.e. not in the vfd_table array.
+ * This is done without holding the vfd_table_mutex. Determining
+ * that a vfd is not in the array is an atomic operation, but the
+ * opposite (determining that is in in the array) requires the mutex to
+ * be locked, as that involves the second step of increasing a ref count.
+ * Thus if this function returns true, one must acquire the vfd_table_mutex,
+ * and check again.
+ */
+static bool
+can_be_in_vfd_table(int vfd)
+{
+	if (!is_in_vfd_table_range(vfd))
+		return false;
+
+	return __atomic_load_n(vfd_table + vfd, __ATOMIC_CONSUME) != NULL;
+}
+
+/*
+ * pmemfile_vfd_ref -- return a vfd_reference, which is either actually
+ * a reference to vfile_description entry, or just holding an fd handled by
+ * the kernel.
+ */
+struct vfd_reference
+pmemfile_vfd_ref(int vfd)
+{
+	if (!can_be_in_vfd_table(vfd)) {
+		/*
+		 * Return a vfd_reference with the field called internal
+		 * set to NULL.
+		 */
+		return (struct vfd_reference) {.kernel_fd = vfd, };
+	}
+
+	util_mutex_lock(&vfd_table_mutex);
+
+	struct vfd_reference result = pmemfile_ref_vfd_under_mutex(vfd);
+
+	util_mutex_unlock(&vfd_table_mutex);
+
+	return result;
+}
+
+static struct vfd_reference
+get_fdcwd_reference(void)
+{
+	struct vfd_reference result;
+
+	util_mutex_lock(&vfd_table_mutex);
+
+	vf_ref_count_inc(cwd_entry);
+
+	result.internal = cwd_entry;
+
+	result.kernel_fd = cwd_entry->kernel_cwd_fd;
+	result.pool = cwd_entry->pool;
+	result.file = cwd_entry->file;
+
+	util_mutex_unlock(&vfd_table_mutex);
+
+	return result;
+}
+
+/*
+ * pmemfile_resolve_at_vfd -- same as pmemfile_resolve_vfd,
+ * except it can resolve AT_FDCWD.
+ * This should only be used for the at directory in appropriate
+ * syscalls.
+ * Calling getdents (and many other syscalls) with AT_FDCWD should
+ * result in EBADF, so pmemfile_vfd_ref should be used for those
+ * cases.
+ */
+struct vfd_reference
+pmemfile_vfd_at_ref(int vfd)
+{
+	if (vfd == AT_FDCWD)
+		return get_fdcwd_reference();
+	else
+		return pmemfile_vfd_ref(vfd);
+}
+
+/*
+ * unref_entry -- internal function, decrases the ref count of an entry, and
+ * releases the resources it holds, if needed.
+ *
+ * There is no need to hold the vfd_table mutex, as this operation does
+ * not touch the vfd table.
+ */
+static void
+unref_entry(struct vfile_description *entry)
+{
+	if (entry == NULL)
+		return;
+
+	if (vf_ref_count_dec_and_fetch(entry) == 0) {
+		if (entry->is_special_cwd_desc) {
+			syscall_no_intercept(SYS_close, entry->kernel_cwd_fd);
+		} else {
+			pool_acquire(entry->pool);
+			pmemfile_close(entry->pool->pool, entry->file);
+			pool_release(entry->pool);
+		}
+		mark_as_free_file_slot(entry);
+	}
+}
+
+/*
+ * pmemfile_vfd_unref -- decrease the ref count associated with an entry
+ * referenced for the user.
+ * There is no need to hold the vfd_table mutex, as this operation does
+ * not touch the vfd table.
+ */
+void
+pmemfile_vfd_unref(struct vfd_reference ref)
+{
+	unref_entry(ref.internal);
+}
+
+/*
+ * pmemfile_vfd_dup -- creates a new reference to a vfile_description entry,
+ * if the vfd refers to one.
+ */
+int
+pmemfile_vfd_dup(int vfd)
+{
+	if (!can_be_in_vfd_table(vfd))
+		return (int)syscall_no_intercept(SYS_dup, vfd);
+
+	int new_vfd;
+	util_mutex_lock(&vfd_table_mutex);
+
+	/*
+	 * First acquire the underlying fd from the kernel. This can
+	 * be the duplicate of a memfd.
+	 */
+	new_vfd = (int)syscall_no_intercept(SYS_dup, vfd);
+
+	if (new_vfd >= 0 && vfd_table[vfd] != NULL) {
+		if (is_in_vfd_table_range(new_vfd)) {
+			assert(vfd_table[new_vfd] == NULL);
+
+			vf_ref_count_inc(vfd_table[vfd]);
+			__atomic_store_n(vfd_table + new_vfd,
+					vfd_table[vfd], __ATOMIC_RELEASE);
+		} else {
+			/* new_vfd can't be used to index the vfd_table */
+			syscall_no_intercept(SYS_close, new_vfd);
+			new_vfd = -ENOMEM;
+		}
+	}
+
+	util_mutex_unlock(&vfd_table_mutex);
+
+	return new_vfd;
+}
+
+/*
+ * vfd_dup2_under_mutex -- perform dup2
+ * If the old_vfd refers to entry, increase the corresponding ref_count.
+ * If the new_vfd refers to entry, decrease the corresponding ref_count.
+ * Overwrite the entry pointer in the vfd_table.
+ * The order of the three operations does not matter, as long as the entries
+ * as different, and all three happen while holding the vfd_table_mutex.
+ *
+ * Important: dup2 must be atomic from the user's point of view.
+ */
+static void
+vfd_dup2_under_mutex(int old_vfd, int new_vfd)
+{
+	/*
+	 * "If oldfd is a valid file descriptor, and newfd has the same value
+	 * as oldfd, then dup2() does nothing, and returns newfd."
+	 *
+	 * It is easily verified if the old vfd is valid or not, by asking
+	 * the kernel to dup2 the underlying (possible) memfd -- see the
+	 * function calling this function.
+	 */
+	if (old_vfd == new_vfd)
+		return;
+
+	if (vfd_table[old_vfd] == vfd_table[new_vfd])
+		return;
+
+	ref_entry(vfd_table[old_vfd]);
+	unref_entry(vfd_table[new_vfd]);
+	__atomic_store_n(vfd_table + new_vfd, vfd_table[old_vfd],
+			__ATOMIC_RELEASE);
+}
+
+/*
+ * pmemfile_vfd_dup2 -- create a new reference to a vfile_description entry,
+ * potentially replacing a reference to another one.
+ */
+int
+pmemfile_vfd_dup2(int old_vfd, int new_vfd)
+{
+	if ((!can_be_in_vfd_table(old_vfd)) && (!can_be_in_vfd_table(new_vfd)))
+		return (int)syscall_no_intercept(SYS_dup2, old_vfd, new_vfd);
+
+	int result;
+
+	util_mutex_lock(&vfd_table_mutex);
+
+	result = (int)syscall_no_intercept(SYS_dup2, old_vfd, new_vfd);
+
+	if (result >= 0) {
+		assert(result == new_vfd);
+		vfd_dup2_under_mutex(old_vfd, new_vfd);
+	}
+
+	util_mutex_unlock(&vfd_table_mutex);
+
+	return result;
+}
+
+/*
+ * pmemfile_vfd_close -- remove a reference from the vfd_table array (if
+ * there was one at vfd_table[vfd]).
+ * This does not necessarily close an underlying pmemfile file, as some
+ * vfd_reference structs given to the user might still reference that entry.
+ */
+long
+pmemfile_vfd_close(int vfd)
+{
+	struct vfile_description *entry = NULL;
+
+	util_mutex_lock(&vfd_table_mutex);
+
+	entry = vfd_table[vfd];
+	vfd_table[vfd] = NULL;
+
+	long result = syscall_no_intercept(SYS_close, vfd);
+
+	util_mutex_unlock(&vfd_table_mutex);
+
+	if (entry != NULL) {
+		assert(!entry->is_special_cwd_desc);
+		unref_entry(entry);
+		result = 0;
+	}
+
+	return result;
+}
+
+/*
+ * setup_cwd -- initializes an entry to hold the cwd, and cwd_entry pointer
+ * to point to it.
+ * Must be called at startup, other functions in this TU expect the cwd_entry
+ * pointer to be non-null.
+ */
+static void
+setup_cwd(void)
+{
+	long fd = syscall_no_intercept(SYS_open, ".", O_DIRECTORY | O_RDONLY);
+	if (fd < 0)
+		exit_with_msg(1, "setup_cwd");
+
+	cwd_entry = fetch_free_file_slot();
+	assert(cwd_entry != NULL); /* Noone else did allocate during startup */
+	cwd_entry->pool = NULL;
+	cwd_entry->file = NULL;
+	cwd_entry->kernel_cwd_fd = (int)fd;
+	cwd_entry->is_special_cwd_desc = true;
+	cwd_entry->ref_count = 1;
+}
+
+/*
+ * pmemfile_vfd_chdir_pf -- change the current working directory to
+ * a pmemfile handled directory.
+ */
+long
+pmemfile_vfd_chdir_pf(struct pool_description *pool, struct pmemfile_file *file)
+{
+	long result;
+	struct vfile_description *old_cwd_entry = NULL;
+
+	pool_acquire(pool);
+	util_mutex_lock(&vfd_table_mutex);
+
+	if (pmemfile_fchdir(pool->pool, file) != 0) {
+		result = -errno;
+	} else {
+		struct vfile_description *entry = fetch_free_file_slot();
+
+		if (entry != NULL) {
+			*entry = (struct vfile_description) {
+				.pool = pool, .file = file,
+				.kernel_cwd_fd = -1,
+				.is_special_cwd_desc = false,
+				.ref_count = 1};
+
+			old_cwd_entry = cwd_entry;
+			cwd_entry = entry;
+			result = 0;
+		} else {
+			result = -ENOMEM;
+			/* Good luck making that line green in codecov! */
+		}
+	}
+
+	util_mutex_unlock(&vfd_table_mutex);
+
+	unref_entry(old_cwd_entry);
+	pool_release(pool);
+
+	return result;
+}
+
+/*
+ * pmemfile_vfd_chdir_kernel_fd -- change the current working directory to
+ * a kernel handled directory.
+ */
+long
+pmemfile_vfd_chdir_kernel_fd(int fd)
+{
+	long result;
+	struct vfile_description *old_cwd_entry = NULL;
+
+	util_mutex_lock(&vfd_table_mutex);
+
+	result = syscall_no_intercept(SYS_fchdir, fd);
+
+	if (result == 0) {
+		struct vfile_description *entry = fetch_free_file_slot();
+
+		if (entry != NULL) {
+			*entry = (struct vfile_description) {
+				.pool = NULL, .file = NULL,
+				.kernel_cwd_fd = fd,
+				.is_special_cwd_desc = true,
+				.ref_count = 1};
+
+			old_cwd_entry = cwd_entry;
+			cwd_entry = entry;
+		} else {
+			result = -ENOMEM;
+		}
+	}
+
+	util_mutex_unlock(&vfd_table_mutex);
+	unref_entry(old_cwd_entry);
+
+	return result;
+}
+
+static bool is_memfd_syscall_available;
+
+#ifdef SYS_memfd_create
+
+static void
+check_memfd_syscall(void)
+{
+	long fd = syscall_no_intercept(SYS_memfd_create, "check", 0);
+	if (fd >= 0) {
+		is_memfd_syscall_available = true;
+		syscall_no_intercept(SYS_close, fd);
+	}
+}
+
+#else
+
+#define SYS_memfd_create 0
+#define check_memfd_syscall()
+
+#endif
+
+/*
+ * acquire_new_fd - grab a new file descriptor from the kernel
+ */
+int
+pmemfile_acquire_new_fd(const char *path)
+{
+	int fd;
+
+	if (is_memfd_syscall_available) {
+		fd = (int)syscall_no_intercept(SYS_memfd_create, path, 0);
+		/* memfd_create can fail for too long name */
+		if (fd < 0) {
+			fd = (int)syscall_no_intercept(SYS_open, "/dev/null",
+					O_RDONLY);
+		}
+	} else {
+		fd = (int)syscall_no_intercept(SYS_open, "/dev/null", O_RDONLY);
+	}
+
+	if (fd >= (long)ARRAY_SIZE(vfd_table)) {
+		syscall_no_intercept(SYS_close, fd);
+		return -ENFILE;
+	}
+
+	return fd;
+}
+
+/*
+ * pmemfile_vfd_assign -- return an fd that can be used by an application
+ * in the future to refer to the given pmemfile file.
+ *
+ * Creates a new vfile_description entry with ref_count = one.
+ */
+int
+pmemfile_vfd_assign(int vfd, struct pool_description *pool,
+			struct pmemfile_file *file,
+			const char *path)
+{
+	struct vfile_description *entry = fetch_free_file_slot();
+
+	if (entry == NULL)
+		return -ENOMEM;
+
+	*entry = (struct vfile_description) {
+		.pool = pool, .file = file,
+		.kernel_cwd_fd = -1,
+		.is_special_cwd_desc = false,
+		.ref_count = 1};
+
+	util_mutex_lock(&vfd_table_mutex);
+
+	vfd_table[vfd] = entry;
+
+	util_mutex_unlock(&vfd_table_mutex);
+
+	return vfd;
+}
+
+long
+pmemfile_vfd_fchdir(int vfd)
+{
+	long result;
+	struct vfile_description *old_cwd_entry = NULL;
+
+	util_mutex_lock(&vfd_table_mutex);
+
+	if (is_in_vfd_table_range(vfd) && vfd_table[vfd] != NULL) {
+		struct vfile_description *cwd = vfd_table[vfd];
+
+		pool_acquire(cwd->pool);
+		result = pmemfile_fchdir(cwd->pool->pool, cwd->file);
+		pool_release(cwd->pool);
+		if (result == 0) {
+			vf_ref_count_inc(vfd_table[vfd]);
+			old_cwd_entry = cwd_entry;
+			cwd_entry = vfd_table[vfd];
+		} else {
+			/*
+			 * Assuming pmemfile_fchdir can't set errno
+			 * to ENOTSUP.
+			 */
+			result = -errno;
+		}
+	} else {
+		/*
+		 * Acquire a new fd to keep in the cwd_entry. This will be
+		 * used in place of AT_FDCWD.
+		 * The user can close the fd originally passed in here,
+		 * so we rely on that. It is going to be closed by unref_entry,
+		 * when it is no longer needed.
+		 */
+		long new_fd = syscall_no_intercept(SYS_dup, vfd);
+		if (new_fd >= 0)
+			result = syscall_no_intercept(SYS_fchdir, new_fd);
+		else
+			result = new_fd;
+
+		if (result == 0) {
+			struct vfile_description *entry;
+			if ((entry = fetch_free_file_slot()) != NULL) {
+				/* XXX Too many nested ifs! */
+				*entry = (struct vfile_description) {
+					.pool = NULL, .file = NULL,
+					.kernel_cwd_fd = (int)new_fd,
+					.is_special_cwd_desc = true,
+					.ref_count = 1};
+
+				old_cwd_entry = cwd_entry;
+				cwd_entry = entry;
+				result = 0;
+			} else {
+				syscall_no_intercept(SYS_close, new_fd);
+				result = -ENOMEM;
+			}
+		}
+	}
+
+	util_mutex_unlock(&vfd_table_mutex);
+
+	unref_entry(old_cwd_entry);
+
+	return result;
+}
+
+void
+pmemfile_vfd_table_init(void)
+{
+	check_memfd_syscall();
+	setup_free_slots();
+	setup_cwd();
+}

--- a/src/libpmemfile/vfd_table.c
+++ b/src/libpmemfile/vfd_table.c
@@ -276,6 +276,50 @@ pmemfile_vfd_unref(struct vfd_reference ref)
 }
 
 /*
+ * vfd_dup2_under_mutex -- perform dup2
+ * If the old_vfd refers to entry, increase the corresponding ref_count.
+ * If the new_vfd refers to entry, decrease the corresponding ref_count.
+ * Overwrite the entry pointer in the vfd_table.
+ * The order of the three operations does not matter, as long as the entries
+ * as different, and all three happen while holding the vfd_table_mutex.
+ *
+ * Important: dup2 must be atomic from the user's point of view.
+ */
+static int
+vfd_dup2_under_mutex(int old_vfd, int new_vfd)
+{
+	if (new_vfd < 0)
+		return new_vfd;
+
+	/*
+	 * "If oldfd is a valid file descriptor, and newfd has the same value
+	 * as oldfd, then dup2() does nothing, and returns newfd."
+	 *
+	 * It is easily verified if the old vfd is valid or not, by asking
+	 * the kernel to dup2 the underlying (possible) memfd -- see the
+	 * function calling this function.
+	 */
+	if (old_vfd == new_vfd)
+		return new_vfd;
+
+	if (!is_in_vfd_table_range(new_vfd)) {
+		/* new_vfd can't be used to index the vfd_table */
+		syscall_no_intercept(SYS_close, new_vfd);
+		return -ENOMEM;
+	}
+
+	if (vfd_table[old_vfd] == vfd_table[new_vfd])
+		return new_vfd;
+
+	ref_entry(vfd_table[old_vfd]);
+	unref_entry(vfd_table[new_vfd]);
+	__atomic_store_n(vfd_table + new_vfd, vfd_table[old_vfd],
+			__ATOMIC_RELEASE);
+
+	return new_vfd;
+}
+
+/*
  * pmemfile_vfd_dup -- creates a new reference to a vfile_description entry,
  * if the vfd refers to one.
  */
@@ -288,62 +332,33 @@ pmemfile_vfd_dup(int vfd)
 	int new_vfd;
 	util_mutex_lock(&vfd_table_mutex);
 
-	/*
-	 * First acquire the underlying fd from the kernel. This can
-	 * be the duplicate of a memfd.
-	 */
 	new_vfd = (int)syscall_no_intercept(SYS_dup, vfd);
 
-	if (new_vfd >= 0 && vfd_table[vfd] != NULL) {
-		if (is_in_vfd_table_range(new_vfd)) {
-			assert(vfd_table[new_vfd] == NULL);
-
-			vf_ref_count_inc(vfd_table[vfd]);
-			__atomic_store_n(vfd_table + new_vfd,
-					vfd_table[vfd], __ATOMIC_RELEASE);
-		} else {
-			/* new_vfd can't be used to index the vfd_table */
-			syscall_no_intercept(SYS_close, new_vfd);
-			new_vfd = -ENOMEM;
-		}
-	}
+	new_vfd = vfd_dup2_under_mutex(vfd, new_vfd);
 
 	util_mutex_unlock(&vfd_table_mutex);
 
 	return new_vfd;
 }
 
-/*
- * vfd_dup2_under_mutex -- perform dup2
- * If the old_vfd refers to entry, increase the corresponding ref_count.
- * If the new_vfd refers to entry, decrease the corresponding ref_count.
- * Overwrite the entry pointer in the vfd_table.
- * The order of the three operations does not matter, as long as the entries
- * as different, and all three happen while holding the vfd_table_mutex.
- *
- * Important: dup2 must be atomic from the user's point of view.
- */
-static void
-vfd_dup2_under_mutex(int old_vfd, int new_vfd)
+int
+pmemfile_vfd_fcntl_dup(int vfd, int min_new_vfd)
 {
-	/*
-	 * "If oldfd is a valid file descriptor, and newfd has the same value
-	 * as oldfd, then dup2() does nothing, and returns newfd."
-	 *
-	 * It is easily verified if the old vfd is valid or not, by asking
-	 * the kernel to dup2 the underlying (possible) memfd -- see the
-	 * function calling this function.
-	 */
-	if (old_vfd == new_vfd)
-		return;
+	if (!can_be_in_vfd_table(vfd))
+		return (int)syscall_no_intercept(SYS_fcntl,
+				vfd, F_DUPFD, min_new_vfd);
 
-	if (vfd_table[old_vfd] == vfd_table[new_vfd])
-		return;
+	int new_vfd;
+	util_mutex_lock(&vfd_table_mutex);
 
-	ref_entry(vfd_table[old_vfd]);
-	unref_entry(vfd_table[new_vfd]);
-	__atomic_store_n(vfd_table + new_vfd, vfd_table[old_vfd],
-			__ATOMIC_RELEASE);
+	new_vfd = (int)syscall_no_intercept(SYS_fcntl,
+				vfd, F_DUPFD, min_new_vfd);
+
+	new_vfd = vfd_dup2_under_mutex(vfd, new_vfd);
+
+	util_mutex_unlock(&vfd_table_mutex);
+
+	return new_vfd;
 }
 
 /*
@@ -362,10 +377,8 @@ pmemfile_vfd_dup2(int old_vfd, int new_vfd)
 
 	result = (int)syscall_no_intercept(SYS_dup2, old_vfd, new_vfd);
 
-	if (result >= 0) {
-		assert(result == new_vfd);
-		vfd_dup2_under_mutex(old_vfd, new_vfd);
-	}
+	assert(result == new_vfd);
+	vfd_dup2_under_mutex(old_vfd, new_vfd);
 
 	util_mutex_unlock(&vfd_table_mutex);
 

--- a/src/libpmemfile/vfd_table.h
+++ b/src/libpmemfile/vfd_table.h
@@ -51,6 +51,7 @@ struct vfd_reference pmemfile_vfd_at_ref(int vfd);
 void pmemfile_vfd_unref(struct vfd_reference);
 
 int pmemfile_vfd_dup(int vfd);
+int pmemfile_vfd_fcntl_dup(int vfd, int min_new_vfd);
 int pmemfile_vfd_dup2(int old_vfd, int new_vfd);
 
 long pmemfile_vfd_close(int vfd);

--- a/src/libpmemfile/vfd_table.h
+++ b/src/libpmemfile/vfd_table.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PMEMFILE_VFD_TABLE_H
+#define PMEMFILE_VFD_TABLE_H
+
+struct vfile_description;
+struct pmemfile_file;
+struct pool_description;
+
+struct vfd_reference {
+	struct pool_description *pool;
+	struct pmemfile_file *file;
+	int kernel_fd;
+	struct vfile_description *internal;
+};
+
+struct vfd_reference pmemfile_vfd_ref(int vfd);
+
+struct vfd_reference pmemfile_vfd_at_ref(int vfd);
+
+void pmemfile_vfd_unref(struct vfd_reference);
+
+int pmemfile_vfd_dup(int vfd);
+int pmemfile_vfd_dup2(int old_vfd, int new_vfd);
+
+long pmemfile_vfd_close(int vfd);
+
+void pmemfile_vfd_table_init(void);
+
+long pmemfile_vfd_chdir_pf(struct pool_description *pool,
+				struct pmemfile_file *file);
+
+long pmemfile_vfd_chdir_kernel_fd(int fd);
+
+long pmemfile_vfd_fchdir(int vfd);
+
+int pmemfile_vfd_assign(int vfd, struct pool_description *pool,
+				struct pmemfile_file *file,
+				const char *path);
+
+int pmemfile_acquire_new_fd(const char *path);
+
+#endif

--- a/tests/preload/CMakeLists.txt
+++ b/tests/preload/CMakeLists.txt
@@ -57,16 +57,20 @@ int main() {
 option(TEST_PROCESS_SWITCHING "test process switching using preload tests" OFF)
 
 add_executable(preload_basic basic/basic.c)
+add_executable(preload_dup dup/dup.c)
+set_target_properties(preload_dup PROPERTIES INCLUDE_DIRECTORIES ${CMAKE_SOURCE_DIR}/src)
 add_executable(preload_config config/config.c)
 add_executable(preload_pool_locking pool_locking/pool_locking.c)
 add_executable(preload_unix unix/unix.c)
 
 add_cstyle(tests-preload-basic ${CMAKE_CURRENT_SOURCE_DIR}/basic/basic.c)
+add_cstyle(tests-preload-dup ${CMAKE_CURRENT_SOURCE_DIR}/dup/dup.c)
 add_cstyle(tests-preload-config ${CMAKE_CURRENT_SOURCE_DIR}/config/config.c)
 add_cstyle(tests-preload-pool-locking ${CMAKE_CURRENT_SOURCE_DIR}/pool_locking/pool_locking.c)
 add_cstyle(tests-preload-unix ${CMAKE_CURRENT_SOURCE_DIR}/unix/unix.c)
 
 add_check_whitespace(tests-preload-basic ${CMAKE_CURRENT_SOURCE_DIR}/basic/basic.c)
+add_check_whitespace(tests-preload-dup ${CMAKE_CURRENT_SOURCE_DIR}/dup/dup.c)
 add_check_whitespace(tests-preload-config ${CMAKE_CURRENT_SOURCE_DIR}/config/config.c)
 add_check_whitespace(tests-preload-pool-locking ${CMAKE_CURRENT_SOURCE_DIR}/pool_locking/pool_locking.c)
 add_check_whitespace(tests-preload-unix ${CMAKE_CURRENT_SOURCE_DIR}/unix/unix.c)
@@ -116,6 +120,7 @@ else()
 endif()
 
 add_test_generic(basic "" $<TARGET_FILE:preload_basic>)
+add_test_generic(dup "" $<TARGET_FILE:preload_dup>)
 add_test_generic(basic_commands "" none)
 add_test_generic(nested_dirs "" none)
 add_test_generic(pool_locking "" $<TARGET_FILE:preload_pool_locking>)

--- a/tests/preload/dup/dup.c
+++ b/tests/preload/dup/dup.c
@@ -203,6 +203,21 @@ test(const char *path, const char *extra_path)
 	}
 }
 
+static void
+test_fcntl_dup(const char *path)
+{
+	int min_new_fd = 177;
+
+	int fd = xcreate(path);
+	int fd2 = fcntl(fd, F_DUPFD, min_new_fd);
+	if (fd2 < 0)
+		err(1, "fcntl");
+
+	assert(fd2 >= min_new_fd);
+
+	seek_and_destroy(fd, fd2);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -222,6 +237,12 @@ main(int argc, char **argv)
 
 	fputs("Testing with pmemfile handled files\n", stderr);
 	test(path_in_pmemf, path_in_kernel);
+
+	fputs("Testing fcntl with cmd=F_DUPFD, with kernel\n", stderr);
+	test_fcntl_dup(path_in_kernel);
+
+	fputs("Testing fcntl with cmd=F_DUPFD, with pmemfile\n", stderr);
+	test_fcntl_dup(path_in_pmemf);
 
 	return 0;
 }

--- a/tests/preload/dup/dup.c
+++ b/tests/preload/dup/dup.c
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * dup.c - a dummy prog using pmemfile, using dup, dup2 via libc
+ */
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+
+#include <assert.h>
+#include <stdio.h>
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "compiler_utils.h"
+
+static int
+xcreate(const char *path)
+{
+	int fd = open(path, O_CREAT | O_RDWR | O_TRUNC, 0700);
+	if (fd < 0)
+		err(1, "open(\"%s\")", path);
+
+	return fd;
+}
+
+static void
+xclose(int fd)
+{
+	if (close(fd) != 0)
+		err(1, "close");
+}
+
+static int
+xdup(int fd)
+{
+	int new_fd = dup(fd);
+	if (new_fd < 0)
+		err(1, "dup");
+
+	return new_fd;
+}
+
+static void
+xdup2(int old, int new)
+{
+	if (dup2(old, new) != new)
+		err(1, "dup2");
+}
+
+static off_t
+xlseek(int fd, off_t offset, int whence)
+{
+	off_t r = lseek(fd, offset, whence);
+	if (r == -1)
+		err(1, "lseek(%d, %ji, %d)", fd, offset, whence);
+
+	return r;
+}
+
+static void
+xwrite(int fd, const void *buffer, size_t size)
+{
+	if (write(fd, buffer, size) != (ssize_t)size)
+		err(1, "write");
+}
+
+static void
+xread(int fd, void *buffer, size_t size)
+{
+	if (read(fd, buffer, size) != (ssize_t)size)
+		err(1, "write");
+}
+
+static void
+seek_and_destroy(int fd0, int fd1)
+{
+	off_t offset = 0;
+	assert(xlseek(fd0, offset, SEEK_SET) == offset);
+	assert(xlseek(fd1, offset, SEEK_CUR) == offset);
+
+	offset = 0x10;
+	assert(xlseek(fd0, offset, SEEK_SET) == offset);
+	assert(xlseek(fd1, 0, SEEK_CUR) == offset);
+
+	offset = 0x40;
+	assert(xlseek(fd1, offset, SEEK_SET) == offset);
+	assert(xlseek(fd0, 0, SEEK_CUR) == offset);
+
+	const char buffer0[] = "My hovercraft is full of eels!";
+	char buffer1[sizeof(buffer0)];
+
+	xwrite(fd0, buffer0, sizeof(buffer0));
+
+	offset += (off_t)sizeof(buffer0);
+
+	assert(xlseek(fd0, 0, SEEK_CUR) == offset);
+	assert(xlseek(fd1, 0, SEEK_CUR) == offset);
+
+	offset -= (off_t)sizeof(buffer0);
+	assert(xlseek(fd1, -((off_t)sizeof(buffer0)), SEEK_CUR) == offset);
+	assert(xlseek(fd0, 0, SEEK_CUR) == offset);
+
+	xread(fd1, buffer1, sizeof(buffer1));
+	assert(memcmp(buffer0, buffer1, sizeof(buffer0)) == 0);
+
+	offset += (off_t)sizeof(buffer0);
+
+	assert(xlseek(fd0, 0, SEEK_CUR) == offset);
+	assert(xlseek(fd1, 0, SEEK_CUR) == offset);
+
+	xclose(fd0);
+	xclose(fd1);
+}
+
+/*
+ * The arguments path and path2 are expected to point to different
+ * domains, i.e. one of the in a pmemfile pool, the other not
+ * in a pmemfile pool.
+ */
+static void
+test(const char *path, const char *extra_path)
+{
+	int fd[0x40];
+
+	fputs("fd and dup'ed fd\n", stderr);
+	fd[0] = xcreate(path);
+	fd[1] = xdup(fd[0]);
+	seek_and_destroy(fd[0], fd[1]);
+
+	fputs("dup'ed fd and original fd\n", stderr);
+	fd[0] = xcreate(path);
+	fd[1] = xdup(fd[0]);
+	seek_and_destroy(fd[1], fd[0]);
+
+	fputs("dup2'd fd and original fd #0\n", stderr);
+	fd[0] = xcreate(path);
+	fd[1] = xdup(fd[0]);
+	xdup2(fd[0], fd[1]);
+	seek_and_destroy(fd[1], fd[0]);
+
+	/* dup2 an fd over another fd from another domain */
+	fputs("dup2'd fd and original fd #1\n", stderr);
+	fd[0] = xcreate(path);
+	fd[1] = xcreate(extra_path);
+	xdup2(fd[0], fd[1]);
+	seek_and_destroy(fd[0], fd[1]);
+
+	fputs("fd array\n", stderr);
+
+	fd[0] = xcreate(path);
+	fd[1] = xcreate(extra_path);
+	for (size_t i = 1; i < ARRAY_SIZE(fd); ++i)
+		fd[i] = xdup(fd[i - 1]);
+	fd[1] = xcreate(extra_path);
+	xdup2(fd[1], fd[ARRAY_SIZE(fd) - 2]);
+
+	size_t left = 0;
+	size_t right = ARRAY_SIZE(fd) - 1;
+
+	while (left < right)
+		seek_and_destroy(fd[left++], fd[right--]);
+
+	fputs("post-close checking\n", stderr);
+	for (size_t i = 1; i < ARRAY_SIZE(fd); ++i) {
+		errno = 0;
+		assert(lseek(fd[i], 1, SEEK_SET) == -1);
+		assert(errno == EBADF);
+	}
+}
+
+int
+main(int argc, char **argv)
+{
+	if (argc < 3)
+		errx(1, "two path arguments required");
+
+	(void) xdup(2);
+
+	if (dup(77) >= 0)
+		errx(1, "dup of non exiting fd did not fail");
+
+	const char *path_in_kernel = argv[1];
+	const char *path_in_pmemf = argv[2];
+
+	fputs("Testing with kernel handled files\n", stderr);
+	test(path_in_kernel, path_in_pmemf);
+
+	fputs("Testing with pmemfile handled files\n", stderr);
+	test(path_in_pmemf, path_in_kernel);
+
+	return 0;
+}

--- a/tests/preload/dup/dup.cmake
+++ b/tests/preload/dup/dup.cmake
@@ -1,0 +1,56 @@
+#
+# Copyright 2017, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+include(${SRC_DIR}/../preload-helpers.cmake)
+
+setup()
+
+mkfs(${DIR}/fs 16m)
+
+execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${DIR}/mount_point)
+execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${DIR}/some_dir)
+
+set(ENV{LD_PRELOAD} ${PRELOAD_LIB})
+set(ENV{PMEMFILE_POOLS} ${DIR}/mount_point:${DIR}/fs)
+set(ENV{PMEMFILE_PRELOAD_LOG} ${BIN_DIR}/pmemfile_preload.log)
+set(ENV{INTERCEPT_LOG} ${BIN_DIR}/intercept.log)
+set(ENV{PMEMFILE_EXIT_ON_NOT_SUPPORTED} 1)
+
+execute_process(COMMAND ${MAIN_EXECUTABLE} ${DIR}/some_dir/filename ${DIR}/mount_point/filename
+                OUTPUT_FILE ${DIR}/root_dir.log
+                RESULT_VARIABLE res)
+if(res)
+        message(FATAL_ERROR "command failed: ${res}")
+endif()
+
+unset(ENV{LD_PRELOAD})
+
+cleanup()

--- a/tests/preload/nested_dirs/nested_dirs.cmake
+++ b/tests/preload/nested_dirs/nested_dirs.cmake
@@ -98,5 +98,6 @@ rmdir(${DIR}/mount_point/test_dir/a/b/c/d/e/f/g/x33)
 list_files(ls_g_no33.log      ${DIR}/mount_point/test_dir/a/b/c/d/e/f/g)
 rmdir(${DIR}/mount_point/test_dir/a/b/c/d/e/f/g/h/i/../../x32)
 list_files(ls_g_no33_no32.log ${DIR}/mount_point/test_dir/a/b/c/d/e/f/g)
+execute(rm -r ${DIR}/mount_point/test_dir/a)
 
 cleanup()

--- a/utils/transform/transform_pmemfile_posix_fd_first.c
+++ b/utils/transform/transform_pmemfile_posix_fd_first.c
@@ -119,7 +119,7 @@ static void
 print_prototype(const struct func_desc *desc, FILE *f)
 {
 	fprintf(f, "static inline %s\n", desc->return_type.name);
-	fprintf(f, "fd_first_%s(struct fd_association *%s",
+	fprintf(f, "fd_first_%s(struct vfd_reference *%s",
 		desc->name + strlen("wrapper_"),
 		desc->args[1].name);
 


### PR DESCRIPTION
This is just an RFC as of now.
This PR contains the commits from #283 .
Also needs more comments and whatnot.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/291)
<!-- Reviewable:end -->

---

As one of the side effects, this removes the need for a special cwd_lock being used for all syscalls that are affected by the CWD.
Thus, all syscalls such as `open`, `stat`, etc.. using paths were serialized before, but with this patch, they can run in paralell.

---

Update:
Now that #283 was merged, I rebased it on the current master. But there were a lot of conflicts with the process switching related changes, so this is still work in progress.
I'm sure there are many places where pool_acquire/pool_release are not used correctly, it will take a while clear it up and be confident about it.