### PR TITLE
posix: fix fallocate PUNCH_HOLE byte zeroing

### DIFF
--- a/src/libpmemfile-posix/fallocate.c
+++ b/src/libpmemfile-posix/fallocate.c
@@ -58,9 +58,7 @@ vinode_fallocate(PMEMfilepool *pfp, struct pmemfile_vinode *vinode, int mode,
 
 	uint64_t off_plus_len = offset + length;
 
-	if (mode & PMEMFILE_FALLOC_FL_PUNCH_HOLE)
-		narrow_to_full_pages(&offset, &length);
-	else
+	if (!(mode & PMEMFILE_FALLOC_FL_PUNCH_HOLE))
 		expand_to_full_pages(&offset, &length);
 
 	if (length == 0)

--- a/src/libpmemfile-posix/utils.c
+++ b/src/libpmemfile-posix/utils.c
@@ -196,25 +196,6 @@ expand_to_full_pages(uint64_t *offset, uint64_t *length)
 	*length = block_roundup(*length);
 }
 
-/*
- * narrow_to_full_pages
- * Alters two file offsets to be pmemfile-page aligned. This is not
- * necessarily the same as memory page alignment!
- * The resulting offset refer to an interval that is contained by the original
- * interval. This new interval can end up being empty, i.e. *length can become
- * zero.
- */
-void
-narrow_to_full_pages(uint64_t *offset, uint64_t *length)
-{
-	uint64_t end = block_rounddown(*offset + *length);
-	*offset = block_roundup(*offset);
-	if (end > *offset)
-		*length = end - *offset;
-	else
-		*length = 0;
-}
-
 void *
 pmemfile_direct(PMEMfilepool *pfp, PMEMoid oid)
 {


### PR DESCRIPTION
fallocate's man page states:
Deallocating file space
  Specifying the FALLOC_FL_PUNCH_HOLE flag (available since Linux 2.6.38) in mode deallocates space (i.e., creates a hole) in the byte range starting at offset and continuing for len bytes.
  Within the specified range, partial filesystem blocks are zeroed, and whole filesystem blocks are removed from the file.
  After a successful call, subsequent reads from this range will return zeroes.

Currently pmemfile_fallocate narrows its punch range to fit blocks inside given range.
Let's say we have 4 blocks at offsets: a, b, c, d...
and we want to punch hole from offset a-5 to d+6
pmemfile_fallocate will set offset to 'a' and length to 'd-a'.

Referring to the manpage this is not correct behaviour - 'partial filesystem blocks are zeroed, and whole filesystem blocks are removed from the file.'
So expected result would be zeroing bytes [a-5; a-1], punching hole in 4 blocks and zeroing [d+1; d+6)

Also I fixed a typo (?) in a comment which was mentioning offset 0x4777 when it wasn't used anywhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/292)
<!-- Reviewable:end -->
