### PR TITLE
utils: alter generation of log_write calls

### DIFF
--- a/src/libpmemfile/libpmemfile-posix-wrappers.h
+++ b/src/libpmemfile/libpmemfile-posix-wrappers.h
@@ -78,11 +78,11 @@ wrapper_pmemfile_pool_open(const char *pathname)
 static inline void
 wrapper_pmemfile_pool_close(PMEMfilepool *pfp)
 {
-	pmemfile_pool_close(pfp);
-
 	log_write(
 	    "pmemfile_pool_close(%p)",
 		pfp);
+
+	pmemfile_pool_close(pfp);
 }
 
 static inline PMEMfile *
@@ -110,12 +110,12 @@ static inline void
 wrapper_pmemfile_close(PMEMfilepool *pfp,
 		PMEMfile *file)
 {
-	pmemfile_close(pfp,
-		file);
-
 	log_write(
 	    "pmemfile_close(%p, %p)",
 		pfp,
+		file);
+
+	pmemfile_close(pfp,
 		file);
 }
 
@@ -1696,12 +1696,12 @@ static inline void
 wrapper_pmemfile_stats(PMEMfilepool *pfp,
 		struct pmemfile_stats *stats)
 {
-	pmemfile_stats(pfp,
-		stats);
-
 	log_write(
 	    "pmemfile_stats(%p, %p)",
 		pfp,
+		stats);
+
+	pmemfile_stats(pfp,
 		stats);
 }
 

--- a/utils/transform/transform_pmemfile_posix.c
+++ b/utils/transform/transform_pmemfile_posix.c
@@ -423,11 +423,17 @@ print_wrapper(struct func_desc *desc, FILE *f)
 {
 	print_prototype(desc, f);
 	fputs("{\n", f);
+	if (desc->return_type.is_void) {
+		print_log_write(desc, f);
+		fputc('\n', f);
+	}
 	print_return_value_assignment(desc, f);
 	print_forward_call(desc, f);
 	handle_errno(desc, f);
-	fputs("\n", f);
-	print_log_write(desc, f);
+	if (!desc->return_type.is_void) {
+		fputc('\n', f);
+		print_log_write(desc, f);
+	}
 	print_function_epilogue(desc, f);
 	fputs("}\n", f);
 	fputs("\n", f);


### PR DESCRIPTION
The code generated by transform_pmemfile_posix.c was sometimes
invalid, in the sense that invalid pointers were logged.
Since those functions which invalidate a pointer
(pmemfile_close, pmemfile_pool_close) have no return value
anyways, the log_write call is moved to be in front of the
forwarding call.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/293)
<!-- Reviewable:end -->
