### PR TITLE
docker: chmod repo

### DIFF
--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -47,6 +47,8 @@ if [[ -z "$HOST_WORKDIR" ]]; then
 	exit 1
 fi
 
+sudo chmod -R a+w $HOST_WORKDIR
+
 if [[ "$TRAVIS_EVENT_TYPE" == "cron" || "$TRAVIS_BRANCH" == "coverity_scan" ]]; then
 	if [[ $COVERITY -eq 1 ]]; then
 		command="./run-coverity.sh"


### PR DESCRIPTION
The build runs with uid 1000 inside docker.
The Precise travis image happens to use this uid for checking
out the sources, but the Trusty travis images uses uid 2000.

This patch makes sure the two uids match.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/303)
<!-- Reviewable:end -->
