### PR TITLE
antool: fix moving vltrace binary log for regeneration

### DIFF
--- a/tests/antool/test-antool.sh
+++ b/tests/antool/test-antool.sh
@@ -131,7 +131,7 @@ if [ ! "$VLTRACE_SKIP" ]; then
 	USER=$(stat --format=%U $TEST_FILE)
 	chown -R $USER.$USER "$DIR"/*
 
-	# remove all logs and match files of the current test
+	# remove all old logs and match files of the current test
 	rm -f *-$TEST_NUM.log*
 	echo "$ sudo bash -c \"$RUN_VLTRACE -o $OUTBIN $TEST_FILE $TEST_NUM $TEST_OPTIONS\""
 	sudo bash -c "$RUN_VLTRACE -o $OUTBIN $TEST_FILE $TEST_NUM $TEST_OPTIONS"
@@ -175,8 +175,10 @@ check
 
 # test succeeded
 # copy vltrace binary log for regeneration
-cp $OUTBIN ..
-cp $FILE_DIR_PMEM ..
+if [ ! "$VLTRACE_SKIP" ]; then
+	mv -f $OUTBIN ..
+	mv -f $FILE_DIR_PMEM ..
+fi
 
 # remove the temporary test directory
 cd ..

--- a/tests/antool/test-parser.sh
+++ b/tests/antool/test-parser.sh
@@ -127,8 +127,8 @@ OUT_VLT=$OUT_BIN
 
 if [ ! "$VLTRACE_SKIP" ]; then
 	require_superuser
-	# remove all logs of the current test
-	rm -f *-$TEST_NUM.log
+	# remove all old logs and match files of the current test
+	rm -f *-$TEST_NUM.log*
 	echo "$ sudo bash -c \"$RUN_VLTRACE $FF -o $OUT_VLT $TEST_FILE $TEST_NUM\""
 	sudo bash -c "$RUN_VLTRACE $FF -o $OUT_VLT $TEST_FILE $TEST_NUM"
 else
@@ -164,7 +164,7 @@ check
 
 # test succeeded
 # copy vltrace binary log for regeneration
-cp $OUT_VLT ..
+[ ! "$VLTRACE_SKIP" ] && mv -f $OUT_VLT ..
 
 # remove the temporary test directory
 cd ..


### PR DESCRIPTION
The essence of the fix is adding the condition:

if [ ! "$VLTRACE_SKIP" ]; then

to the test scripts, so that the binary log is not copied now,
because it is unnecessary and wrong when the log is not regenerated.
Copying the log when running parallel tests causes test failures.

Ref: #290

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/311)
<!-- Reviewable:end -->
