### PR TITLE
Pmemfile posix static library

### DIFF
--- a/src/libpmemfile-posix/CMakeLists.txt
+++ b/src/libpmemfile-posix/CMakeLists.txt
@@ -223,7 +223,6 @@ target_link_libraries(pmemfile-posix_shared PRIVATE ${CMAKE_THREAD_LIBS_INIT})
 target_link_libraries(pmemfile-posix_shared PRIVATE -Wl,--version-script=${CMAKE_CURRENT_BINARY_DIR}/libpmemfile-posix.map)
 set_target_properties(pmemfile-posix_shared PROPERTIES LINK_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/libpmemfile-posix.map)
 
-set_target_properties(pmemfile-posix_static_unscoped PROPERTIES OUTPUT_NAME pmemfile-posix_unscoped)
 set_target_properties(pmemfile-posix_shared PROPERTIES OUTPUT_NAME pmemfile-posix)
 set_target_properties(pmemfile-posix_shared PROPERTIES VERSION ${VERSION} SOVERSION ${VERSION_MAJOR})
 
@@ -232,11 +231,24 @@ if(NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug")
 		PUBLIC_HEADER "${CMAKE_SOURCE_DIR}/include/libpmemfile-posix.h;${CMAKE_SOURCE_DIR}/include/libpmemfile-posix-stubs.h")
 endif()
 
-add_custom_command(OUTPUT libpmemfile-posix.a
-		COMMAND objcopy --localize-hidden ${OBJDUMP_EXPORTED_SYMBOLS} libpmemfile-posix_unscoped.a libpmemfile-posix.a
-		DEPENDS pmemfile-posix_static_unscoped
+set(posix_unscoped_a $<TARGET_FILE:pmemfile-posix_static_unscoped>)
+
+add_custom_command(OUTPUT pmemfile-posix_unscoped.o
+		COMMAND ${CMAKE_LINKER} -r --whole-archive ${posix_unscoped_a}
+					-o pmemfile-posix_unscoped.o
+		DEPENDS pmemfile-posix_static_unscoped)
+
+add_custom_command(OUTPUT pmemfile-posix_scoped.o
+		COMMAND ${CMAKE_OBJCOPY} --localize-hidden
+				${OBJDUMP_EXPORTED_SYMBOLS}
+				pmemfile-posix_unscoped.o pmemfile-posix_scoped.o
+		DEPENDS pmemfile-posix_unscoped.o
 		DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/libpmemfile-posix.map)
-add_custom_target(pmemfile-posix_static ALL DEPENDS libpmemfile-posix.a)
+
+add_library(pmemfile-posix_static STATIC pmemfile-posix_scoped.o)
+set_target_properties(pmemfile-posix_static PROPERTIES LINKER_LANGUAGE C)
+set_target_properties(pmemfile-posix_static PROPERTIES OUTPUT_NAME pmemfile-posix)
+target_link_libraries(pmemfile-posix_static INTERFACE ${PMEMOBJ_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
 install(TARGETS pmemfile-posix_shared
 	CONFIGURATIONS Release None RelWithDebInfo

--- a/tests/posix/CMakeLists.txt
+++ b/tests/posix/CMakeLists.txt
@@ -29,6 +29,9 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+# XXX Needed for using libpmemfile-posix_static
+link_directories(${PMEMOBJ_LIBRARY_DIRS})
+
 add_c_flag(-fno-strict-aliasing)
 
 # GTest macros trigger this warning with GCC7. The code is correct
@@ -92,34 +95,47 @@ add_check_whitespace("tests-posix-test" ${CMAKE_CURRENT_SOURCE_DIR}/*.*pp)
 add_cstyle(tests-posix-test_bt ${CMAKE_CURRENT_SOURCE_DIR}/../test_backtrace.c)
 add_check_whitespace(tests-posix-test_bt ${CMAKE_CURRENT_SOURCE_DIR}/../test_backtrace.c)
 
-function(build_test name srcs)
+function(build_test name posix_lib srcs)
 	add_cppstyle(tests-posix-${name} ${CMAKE_CURRENT_SOURCE_DIR}/${srcs})
 	add_check_whitespace(tests-posix-${name} ${CMAKE_CURRENT_SOURCE_DIR}/${srcs})
 	add_executable(${name} ${srcs})
-	target_link_libraries(${name} pmemfile-posix_shared pmemfile_test test_backtrace)
+	target_link_libraries(${name} ${posix_lib} pmemfile_test test_backtrace)
 	if(LIBUNWIND_FOUND)
 		target_link_libraries(${name} ${LIBUNWIND_LIBRARIES} ${CMAKE_DL_LIBS})
 	endif()
 	add_dependencies(tests ${name})
 endfunction()
 
-build_test(file_basic basic/basic.cpp)
-build_test(file_pointer_caching pointer_caching/pointer_caching.cpp)
-build_test(file_crash crash/crash.cpp)
-build_test(file_dirs dirs/dirs.cpp)
-build_test(file_getdents getdents/getdents.cpp)
-build_test(file_mt mt/mt.cpp)
-build_test(file_openp openp/openp.cpp)
-build_test(file_permissions permissions/permissions.cpp)
-build_test(file_rw rw/rw.cpp)
-build_test(file_stat stat/stat.cpp)
-build_test(file_symlinks symlinks/symlinks.cpp)
-build_test(file_timestamps timestamps/timestamps.cpp)
+function(build_test_using_shared name srcs)
+	build_test(${name} pmemfile-posix_shared ${srcs})
+endfunction()
+
+function(build_test_using_static name srcs)
+	build_test(${name} pmemfile-posix_static ${srcs})
+endfunction()
+
+build_test_using_shared(file_basic basic/basic.cpp)
+build_test_using_static(file_basic_using_static basic/basic.cpp)
+build_test_using_shared(file_pointer_caching pointer_caching/pointer_caching.cpp)
+build_test_using_shared(file_crash crash/crash.cpp)
+build_test_using_shared(file_dirs dirs/dirs.cpp)
+build_test_using_shared(file_getdents getdents/getdents.cpp)
+build_test_using_shared(file_mt mt/mt.cpp)
+build_test_using_shared(file_openp openp/openp.cpp)
+build_test_using_shared(file_permissions permissions/permissions.cpp)
+build_test_using_shared(file_rw rw/rw.cpp)
+build_test_using_shared(file_stat stat/stat.cpp)
+build_test_using_shared(file_symlinks symlinks/symlinks.cpp)
+build_test_using_shared(file_timestamps timestamps/timestamps.cpp)
 
 # Configures test ${name} using tracer ${tracer} and gtest filter ${filter}
 # Optional next argument is passed as is to test.
 # Optional next argument is appended to environment variables.
-function(add_test_with_filter name filter tracer)
+function(add_test_with_filter name filter tracer executable)
+	if ("${executable}" STREQUAL "")
+		set(executable ${name})
+	endif()
+
 	set(vg_tracers memcheck helgrind drd pmemcheck)
 	if ("${filter}" STREQUAL "")
 		set(filter_postfix)
@@ -147,16 +163,16 @@ function(add_test_with_filter name filter tracer)
 		return()
 	endif()
 
-	add_test(NAME ${name}${filter_postfix}_${tracer}
+	add_test(NAME ${executable}${filter_postfix}_${tracer}
 		COMMAND ${CMAKE_COMMAND}
 			${GLOBAL_TEST_ARGS}
-			-DTEST_NAME=${name}${filter_postfix}_${tracer}
+			-DTEST_NAME=${executable}${filter_postfix}_${tracer}
 			-DSRC_DIR=${CMAKE_CURRENT_SOURCE_DIR}/${name}
-			-DBIN_DIR=${CMAKE_CURRENT_BINARY_DIR}/${name}${filter_postfix}_${tracer}
-			-DTEST_EXECUTABLE=$<TARGET_FILE:file_${name}>
+			-DBIN_DIR=${CMAKE_CURRENT_BINARY_DIR}/${executable}${filter_postfix}_${tracer}
+			-DTEST_EXECUTABLE=$<TARGET_FILE:file_${executable}>
 			-DTRACER=${tracer}
 			-DLONG_TESTS=${LONG_TESTS}
-			${ARGV3}
+			${ARGV4}
 			${filter_cmd}
 			-P ${CMAKE_CURRENT_SOURCE_DIR}/${name}/${name}.cmake)
 
@@ -166,10 +182,15 @@ function(add_test_with_filter name filter tracer)
 endfunction()
 
 function(add_test_generic name tracer)
-	add_test_with_filter(${name} "" ${tracer} ${ARGN})
+	add_test_with_filter(${name} "" ${tracer} ${name} ${ARGN})
+endfunction()
+
+function(add_test_generic_with_exe name tracer executable)
+	add_test_with_filter(${name} "" ${tracer} ${executable} ${ARGN})
 endfunction()
 
 add_test_generic(basic none)
+add_test_generic_with_exe(basic none basic_using_static)
 add_test_generic(basic memcheck)
 add_test_generic(basic helgrind)
 add_test_generic(basic pmemcheck)
@@ -185,7 +206,7 @@ add_test_generic(crash none)
 
 add_test_generic(dirs none)
 add_test_generic(dirs memcheck)
-add_test_generic(dirs helgrind  -Dops=10)
+add_test_generic(dirs helgrind -Dops=10)
 add_test_generic(dirs drd)
 add_test_generic(dirs pmemcheck -Dops=10)
 
@@ -194,11 +215,11 @@ add_test_generic(getdents memcheck)
 add_test_generic(getdents pmemcheck)
 
 function(add_mt_test tracer ops)
-	add_test_with_filter(mt open_close_create_unlink ${tracer} -Dops=${ops})
-	add_test_with_filter(mt pread                    ${tracer} -Dops=${ops})
-	add_test_with_filter(mt rename                   ${tracer} -Dops=${ops})
-	add_test_with_filter(mt rename_random_paths      ${tracer} -Dops=${ops})
-	add_test_with_filter(mt exchange_random_paths    ${tracer} -Dops=${ops})
+	add_test_with_filter(mt open_close_create_unlink ${tracer} "" -Dops=${ops})
+	add_test_with_filter(mt pread                    ${tracer} "" -Dops=${ops})
+	add_test_with_filter(mt rename                   ${tracer} "" -Dops=${ops})
+	add_test_with_filter(mt rename_random_paths      ${tracer} "" -Dops=${ops})
+	add_test_with_filter(mt exchange_random_paths    ${tracer} "" -Dops=${ops})
 endfunction()
 
 if(LONG_TESTS)

--- a/tests/posix/CMakeLists.txt
+++ b/tests/posix/CMakeLists.txt
@@ -107,13 +107,17 @@ function(build_test name posix_lib srcs)
 endfunction()
 
 function(build_test_using_shared name srcs)
+	# Build an executable for testing, linked to the pmemfile-posix shared library
 	build_test(${name} pmemfile-posix_shared ${srcs})
 endfunction()
 
 function(build_test_using_static name srcs)
+	# Build an executable for testing, linked with the pmemfile-posix static library
 	build_test(${name} pmemfile-posix_static ${srcs})
 endfunction()
 
+# We use basic/basic.cpp twice: running the same test once using the dynamically loaded
+# shared library, and once using the static library (libpmemfile-posix.a).
 build_test_using_shared(file_basic basic/basic.cpp)
 build_test_using_static(file_basic_using_static basic/basic.cpp)
 build_test_using_shared(file_pointer_caching pointer_caching/pointer_caching.cpp)


### PR DESCRIPTION
The static library had type UTILITY, which was not usable in the link_target_libraries command.
This patch creates a usable STATIC library, i.e. cmake understads it is a static library.
Also, partial linking is done before hiding symbols.

Also, adding a test using the static library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/313)
<!-- Reviewable:end -->
