### PR TITLE
tests: fail tests when ASAN/UBSAN prints non-fatal message

### DIFF
--- a/pmemfile-debug.spec
+++ b/pmemfile-debug.spec
@@ -58,7 +58,7 @@ make install DESTDIR=%{buildroot}
 
 %check
 cd dbg_build
-ctest -V %{?_smp_mflags} --output-on-failure
+ctest %{?_smp_mflags} --output-on-failure
 
 %changelog
 * Tue Feb 14 2017 Marcin Ślusarz <marcin.slusarz@intel.com> - 0.1-1

--- a/pmemfile.spec
+++ b/pmemfile.spec
@@ -90,7 +90,7 @@ make install DESTDIR=%{buildroot}
 
 %check
 cd build
-ctest -V %{?_smp_mflags} --output-on-failure
+ctest %{?_smp_mflags} --output-on-failure
 
 %post   -n libpmemfile-posix -p /sbin/ldconfig
 %postun -n libpmemfile-posix -p /sbin/ldconfig

--- a/tests/posix/CMakeLists.txt
+++ b/tests/posix/CMakeLists.txt
@@ -161,7 +161,8 @@ function(add_test_with_filter name filter tracer)
 			-P ${CMAKE_CURRENT_SOURCE_DIR}/${name}/${name}.cmake)
 
 	set_tests_properties(${name}${filter_postfix}_${tracer} PROPERTIES
-		ENVIRONMENT "LC_ALL=C;PATH=$ENV{PATH};${ARGV4}")
+		ENVIRONMENT "LC_ALL=C;PATH=$ENV{PATH};${ARGV4}"
+		FAIL_REGULAR_EXPRESSION Sanitizer)
 endfunction()
 
 function(add_test_generic name tracer)

--- a/tests/posix/posix-helpers.cmake
+++ b/tests/posix/posix-helpers.cmake
@@ -81,12 +81,13 @@ function(execute name)
 		unset(ENV{PMEM_IS_PMEM_FORCE})
 	endif()
 
+	message(STATUS "Test ${name}:")
+	file(READ ${BIN_DIR}/${TRACER}.out OUT)
+	message(STATUS "Stdout:\n${OUT}")
+	file(READ ${BIN_DIR}/${TRACER}.err ERR)
+	message(STATUS "Stderr:\n${ERR}")
+
 	if(HAD_ERROR)
-		message(STATUS "Test ${name} failed: ${HAD_ERROR}")
-		file(READ ${BIN_DIR}/${TRACER}.out OUT)
-		message(STATUS "Stdout:\n${OUT}")
-		file(READ ${BIN_DIR}/${TRACER}.err ERR)
-		message(STATUS "Stderr:\n${ERR}")
 		message(FATAL_ERROR "Test ${name} failed: ${HAD_ERROR}")
 	endif()
 


### PR DESCRIPTION
Now ctest -V will print stdout and stderr of all tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/320)
<!-- Reviewable:end -->
