### PR TITLE
posix: handle another case when we rely on undefined behavior in lseek

### DIFF
--- a/src/libpmemfile-posix/lseek.c
+++ b/src/libpmemfile-posix/lseek.c
@@ -229,9 +229,15 @@ lseek_seek_data_or_hole(PMEMfilepool *pfp, struct pmemfile_vinode *vinode,
 static inline pmemfile_off_t
 add_off(size_t cur, pmemfile_off_t off)
 {
-	if (off >= 0)
-		return (pmemfile_off_t)(cur + (size_t)off);
-	return (pmemfile_off_t)(cur - (size_t)-off);
+	COMPILE_ERROR_ON(sizeof(cur) != sizeof(int64_t));
+	ASSERT(cur <= INT64_MAX);
+
+	cur += (size_t)off;
+
+	if (cur > INT64_MAX)
+		return -1;
+
+	return (pmemfile_off_t)cur;
 }
 
 /*


### PR DESCRIPTION
SUMMARY: AddressSanitizer: undefined-behavior src/libpmemfile-posix/lseek.c:234:40 in
src/libpmemfile-posix/lseek.c:234:40: runtime error: negation of -9223372036854775808 cannot be represented in type 'pmemfile_off_t' (aka 'long'); cast to an unsigned type to negate this value to itself

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/322)
<!-- Reviewable:end -->
