### PR TITLE
Codecov.io integration improvements.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,22 @@
-ignore:
-  - utils/check_license/check-license.c
+coverage:
+  status:
+    project:
+      posix:
+        paths:
+          - src/libpmemfile-posix/
+      preload:
+        paths:
+          - src/libpmemfile/
+      antool:
+        paths:
+          - src/tools/antool/
+      other:
+        paths:
+          - src/tools/mkfs.pmemfile.c
+          - src/tools/pmemfile-cat.c
+          - src/tools/pmemfile-mount.c
+  ignore:
+    - utils/
+    - tests/
+    - src/valgrind/
+    - src/libpmemfile/sys_util.h

--- a/utils/docker/sqlite/run-build-sqlite.sh
+++ b/utils/docker/sqlite/run-build-sqlite.sh
@@ -84,7 +84,7 @@ set +e
 	--timeout 120
 
 if [ "$COVERAGE" = "1" ]; then
-	bash <(curl -s https://codecov.io/bash)
+	bash <(curl -s https://codecov.io/bash) -c -F sqlite_tests
 fi
 
 cd $WORKDIR


### PR DESCRIPTION
- Submit results for each group of tests separately.
  Now it's possible to see how each group of tests contributes to overall
  and per-file coverage.
- Add projects.
  With that it's possible to see how PR affects each library / tool.
- Disable reporting of coverage for tests, utils, valgrind headers and
  error handling wrappers (sys_util.h).
  Measuring code coverage of tests and utils (which is run only during
  build) doesn't make any sense. Disabling that decreases overall code
  coverage, but it's the right thing to do.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/331)
<!-- Reviewable:end -->
