### PR TITLE
tests: test process switching using preload tests

### DIFF
--- a/debian/debug/rules
+++ b/debian/debug/rules
@@ -10,4 +10,4 @@ override_dh_shlibdeps:
 	dh_shlibdeps  -O--buildsystem=cmake -l /usr/lib/x86_64-linux-gnu/pmemfile_debug
 
 override_dh_auto_test:
-	dh_auto_test -- ARGS+=--output-on-failure
+	dh_auto_test -- ARGS+="-E preload_unix --output-on-failure"

--- a/debian/rules
+++ b/debian/rules
@@ -7,4 +7,4 @@ override_dh_auto_configure:
 	dh_auto_configure -- -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTESTS_USE_FORCED_PMEM=1
 
 override_dh_auto_test:
-	dh_auto_test -- ARGS+=--output-on-failure
+	dh_auto_test -- ARGS+="-E preload_unix --output-on-failure"

--- a/pmemfile-debug.spec
+++ b/pmemfile-debug.spec
@@ -58,7 +58,7 @@ make install DESTDIR=%{buildroot}
 
 %check
 cd dbg_build
-ctest %{?_smp_mflags} --output-on-failure
+ctest %{?_smp_mflags} -E preload_unix --output-on-failure
 
 %changelog
 * Tue Feb 14 2017 Marcin Ślusarz <marcin.slusarz@intel.com> - 0.1-1

--- a/pmemfile.spec
+++ b/pmemfile.spec
@@ -95,7 +95,7 @@ make install DESTDIR=%{buildroot}
 
 %check
 cd build
-ctest %{?_smp_mflags} --output-on-failure
+ctest %{?_smp_mflags} -E preload_unix --output-on-failure
 
 %post   -n libpmemfile-posix -p /sbin/ldconfig
 %postun -n libpmemfile-posix -p /sbin/ldconfig

--- a/tests/preload/CMakeLists.txt
+++ b/tests/preload/CMakeLists.txt
@@ -54,8 +54,6 @@ int main() {
 }
 " XATTR_AVAILABLE_IN_TEST_DIR)
 
-option(TEST_PROCESS_SWITCHING "test process switching using preload tests" OFF)
-
 add_executable(preload_basic basic/basic.c)
 add_executable(preload_dup dup/dup.c)
 set_target_properties(preload_dup PROPERTIES INCLUDE_DIRECTORIES ${CMAKE_SOURCE_DIR}/src)
@@ -100,11 +98,10 @@ function(add_test_generic name sub_name main_executable)
 		COMMAND ${CMAKE_COMMAND}
 			${GLOBAL_TEST_ARGS}
 			-DTEST_NAME=${name}${sub_name}
-			-DSRC_DIR=${CMAKE_CURRENT_SOURCE_DIR}/${name}${sub_name}
+			-DSRC_DIR=${CMAKE_CURRENT_SOURCE_DIR}/${name}
 			-DBIN_DIR=${CMAKE_CURRENT_BINARY_DIR}/${name}${sub_name}
 			-DPRELOAD_LIB=${PRELOAD_LIB_LIST}
 			-DMAIN_EXECUTABLE=${main_executable}
-			-DTEST_PROCESS_SWITCHING=${TEST_PROCESS_SWITCHING}
 			${ARGN}
 			-P ${CMAKE_CURRENT_SOURCE_DIR}/${name}/${name}.cmake)
 
@@ -112,16 +109,21 @@ function(add_test_generic name sub_name main_executable)
 		ENVIRONMENT "LC_ALL=C")
 endfunction()
 
+function(add_test_generic_ps name sub_name main_executable)
+	add_test_generic(${name} "${sub_name}"                        ${main_executable}                            ${ARGN})
+	add_test_generic(${name} "${sub_name}_with_process_switching" ${main_executable} -DTEST_PROCESS_SWITCHING=1 ${ARGN})
+endfunction()
+
 find_program(SQLITE3 sqlite3)
 if (SQLITE3)
-	add_test_generic(sqlite "" none)
+	add_test_generic_ps(sqlite "" none)
 else()
 	add_test(NAME sqlite_SKIPPED_BECAUSE_OF_MISSING_SQLITE3 COMMAND true)
 endif()
 
-add_test_generic(basic "" $<TARGET_FILE:preload_basic>)
-add_test_generic(dup "" $<TARGET_FILE:preload_dup>)
-add_test_generic(basic_commands "" none)
+add_test_generic_ps(basic "" $<TARGET_FILE:preload_basic>)
+add_test_generic_ps(dup "" $<TARGET_FILE:preload_dup>)
+add_test_generic_ps(basic_commands "" none)
 add_test_generic(nested_dirs "" none)
 add_test_generic(pool_locking "" $<TARGET_FILE:preload_pool_locking>)
 
@@ -153,11 +155,11 @@ add_test_generic(config "_outer_via_invalid" $<TARGET_FILE:preload_config> -DTES
 set_tests_properties("preload_config_outer_via_invalid"
 	PROPERTIES PASS_REGULAR_EXPRESSION "EIO")
 
-add_test_generic(unix "" $<TARGET_FILE:preload_unix>)
+add_test_generic_ps(unix "" $<TARGET_FILE:preload_unix>)
 
 if(XATTR_AVAILABLE_IN_TEST_DIR)
 	add_executable(preload_xattr xattr/xattr.c)
 	add_cstyle(tests-preload-xattr ${CMAKE_CURRENT_SOURCE_DIR}/xattr/xattr.c)
 	add_check_whitespace(tests-preload-xattr ${CMAKE_CURRENT_SOURCE_DIR}/xattr/xattr.c)
-	add_test_generic(xattr "" $<TARGET_FILE:preload_xattr>)
+	add_test_generic_ps(xattr "" $<TARGET_FILE:preload_xattr>)
 endif()

--- a/utils/docker/run-coverage.sh
+++ b/utils/docker/run-coverage.sh
@@ -43,6 +43,7 @@ mkdir build
 cd build
 cmake .. -DDEVELOPER_MODE=1 \
 		-DCMAKE_BUILD_TYPE=Debug \
+		-DTEST_DIR=/tmp/pmemfile-tests \
 		-DTRACE_TESTS=1 \
 		-DTESTS_USE_FORCED_PMEM=1 \
 		-DAUTO_GENERATE_SOURCES=$AUTOGENSOURCES \


### PR DESCRIPTION
Not all of them are used:
- "nested_dirs" is too slow with nvml 1.3
- "pool_locking" is extremely slow, even with nvml master
- "config_*" tests test only the initialization of libpmemfile

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/336)
<!-- Reviewable:end -->
