### PR TITLE
preload: fix truncate for paths outside of pmemfile pool

### DIFF
--- a/tests/preload/basic/basic.c
+++ b/tests/preload/basic/basic.c
@@ -97,6 +97,23 @@ main(int argc, char **argv)
 	if (chdir(chdir_path) != 0)
 		err(1, "chdir to \"%s\"", chdir_path);
 
+	/* Test file access outside of pmemfile pool. */
+	if (truncate("trunc_test", 10) == 0)
+		err(1, "truncate trunc_test 10 unexpectedly succeeded");
+
+	if (unlink("trunc_test") == 0)
+		err(1, "unlink trunc_test unexpectedly succeeded");
+
+	if ((fd = creat("trunc_test", 0777) < 0))
+		err(1, "creat trunc_test");
+	close(fd);
+
+	if (truncate("trunc_test", 10))
+		err(1, "truncate trunc_test 10");
+
+	if (unlink("trunc_test"))
+		err(1, "unlink trunc_test");
+
 	/*
 	 * Creating a file with an relative path,
 	 * and writing to it.

--- a/tests/preload/basic_commands/basic_commands.cmake
+++ b/tests/preload/basic_commands/basic_commands.cmake
@@ -130,4 +130,15 @@ set(ENV{PMEMFILE_CD} ${DIR}/mount_point)
 execute(stat ../dummy_file_a)
 unset(ENV{PMEMFILE_CD})
 
+# test syscalls for paths outside of pmemfile mount point
+execute(touch ${DIR}/out_file)
+execute(truncate -s 10 ${DIR}/out_file)
+execute_expect_failure(truncate -s 10 ${DIR}/bla/out_file)
+execute(mv ${DIR}/out_file ${DIR}/out_file2)
+execute_expect_failure(mv ${DIR}/out_file ${DIR}/out_file2)
+execute_expect_failure(mv ${DIR}/out_file2 ${DIR}/bla/out_file)
+# cross-device rename
+execute(mv ${DIR}/out_file2 ${DIR}/mount_point/out_file)
+execute(rm ${DIR}/mount_point/out_file)
+
 cleanup()


### PR DESCRIPTION
... when path crosses pmemfile mount point

Ref: #306

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/337)
<!-- Reviewable:end -->
