### PR TITLE
posix: remove pmemfile_dup*

### DIFF
--- a/include/libpmemfile-posix-stubs.h
+++ b/include/libpmemfile-posix-stubs.h
@@ -52,9 +52,6 @@
 
 int pmemfile_flock(PMEMfilepool *, PMEMfile *file, int operation);
 
-PMEMfile *pmemfile_dup(PMEMfilepool *, PMEMfile *);
-PMEMfile *pmemfile_dup2(PMEMfilepool *, PMEMfile *file, PMEMfile *file2);
-
 void *pmemfile_mmap(PMEMfilepool *, void *addr, size_t len,
 		int prot, int flags, PMEMfile *file, pmemfile_off_t off);
 int pmemfile_munmap(PMEMfilepool *, void *addr, size_t len);

--- a/src/libpmemfile-posix/CMakeLists.txt
+++ b/src/libpmemfile-posix/CMakeLists.txt
@@ -106,8 +106,6 @@ set(EXPORTED_SYMBOLS
 	pmemfile_clrcap
 	pmemfile_copy_file_range
 	pmemfile_create
-	pmemfile_dup
-	pmemfile_dup2
 	pmemfile_errormsg
 	pmemfile_euidaccess
 	pmemfile_faccessat

--- a/src/libpmemfile-posix/file.c
+++ b/src/libpmemfile-posix/file.c
@@ -706,20 +706,6 @@ pmemfile_close(PMEMfilepool *pfp, PMEMfile *file)
 	pf_free(file);
 }
 
-PMEMfile *
-pmemfile_dup(PMEMfilepool *pfp, PMEMfile *file)
-{
-	errno = ENOTSUP;
-	return NULL;
-}
-
-PMEMfile *
-pmemfile_dup2(PMEMfilepool *pfp, PMEMfile *file, PMEMfile *file2)
-{
-	errno = ENOTSUP;
-	return NULL;
-}
-
 pmemfile_mode_t
 pmemfile_umask(PMEMfilepool *pfp, pmemfile_mode_t mask)
 {

--- a/src/libpmemfile/libpmemfile-posix-wrappers.h
+++ b/src/libpmemfile/libpmemfile-posix-wrappers.h
@@ -1944,45 +1944,6 @@ wrapper_pmemfile_flock(PMEMfilepool *pfp,
 	return ret;
 }
 
-static inline PMEMfile *
-wrapper_pmemfile_dup(PMEMfilepool *pfp,
-		PMEMfile *file)
-{
-	PMEMfile *ret;
-
-	ret = pmemfile_dup(pfp,
-		file);
-
-	log_write(
-	    "pmemfile_dup(%p, %p) = %p",
-		pfp,
-		file,
-		ret);
-
-	return ret;
-}
-
-static inline PMEMfile *
-wrapper_pmemfile_dup2(PMEMfilepool *pfp,
-		PMEMfile *file,
-		PMEMfile *file2)
-{
-	PMEMfile *ret;
-
-	ret = pmemfile_dup2(pfp,
-		file,
-		file2);
-
-	log_write(
-	    "pmemfile_dup2(%p, %p, %p) = %p",
-		pfp,
-		file,
-		file2,
-		ret);
-
-	return ret;
-}
-
 static inline void *
 wrapper_pmemfile_mmap(PMEMfilepool *pfp,
 		void *addr,


### PR DESCRIPTION
dup/dup2 is implemented on libpmemfile.so side without any help from
libpmemfile-posix.so.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/342)
<!-- Reviewable:end -->
