### PR TITLE
docker: update pjdfstest results

### DIFF
--- a/utils/docker/pjdfstest/pmemfile-summary.log.match
+++ b/utils/docker/pjdfstest/pmemfile-summary.log.match
@@ -1,44 +1,40 @@
 Test Summary Report
 -------------------
-$(S)/pjdfstest/tests/chmod/03.t          (Wstat: 256 Tests: 5 Failed: 0)
-  Non-zero exit status: 1
+$(S)/pjdfstest/tests/chmod/02.t          (Wstat: 0 Tests: 5 Failed: 1)
+  Failed test:  5
 $(S)/pjdfstest/tests/chmod/10.t          (Wstat: 0 Tests: 2 Failed: 1)
   Failed test:  2
 $(S)/pjdfstest/tests/chown/00.t          (Wstat: 0 Tests: 467 Failed: 8)
   Failed tests:  230, 234, 245-246, 251-252, 266, 270
   TODO passed:   385, 389, 395, 400, 404, 410, 415
-$(S)/pjdfstest/tests/chown/03.t          (Wstat: 256 Tests: 10 Failed: 0)
-  Non-zero exit status: 1
+$(S)/pjdfstest/tests/chown/02.t          (Wstat: 0 Tests: 10 Failed: 2)
+  Failed tests:  5, 10
 $(S)/pjdfstest/tests/chown/10.t          (Wstat: 0 Tests: 4 Failed: 2)
   Failed tests:  2, 4
 $(S)/pjdfstest/tests/ftruncate/00.t      (Wstat: 0 Tests: 26 Failed: 1)
   Failed test:  18
-$(S)/pjdfstest/tests/ftruncate/03.t      (Wstat: 256 Tests: 5 Failed: 0)
-  Non-zero exit status: 1
+$(S)/pjdfstest/tests/ftruncate/02.t      (Wstat: 0 Tests: 5 Failed: 1)
+  Failed test:  5
 $(S)/pjdfstest/tests/ftruncate/14.t      (Wstat: 0 Tests: 2 Failed: 1)
   Failed test:  2
-$(S)/pjdfstest/tests/link/03.t           (Wstat: 256 Tests: 13 Failed: 0)
-  Non-zero exit status: 1
+$(S)/pjdfstest/tests/link/02.t           (Wstat: 0 Tests: 10 Failed: 2)
+  Failed tests:  8, 10
 $(S)/pjdfstest/tests/link/17.t           (Wstat: 0 Tests: 8 Failed: 4)
   Failed tests:  3, 6-8
-$(S)/pjdfstest/tests/mkdir/03.t          (Wstat: 256 Tests: 3 Failed: 0)
-  Non-zero exit status: 1
+$(S)/pjdfstest/tests/mkdir/02.t          (Wstat: 0 Tests: 3 Failed: 1)
+  Failed test:  3
 $(S)/pjdfstest/tests/mkdir/12.t          (Wstat: 0 Tests: 2 Failed: 1)
   Failed test:  2
-$(S)/pjdfstest/tests/open/00.t           (Wstat: 0 Tests: 47 Failed: 3)
-  Failed tests:  41, 43-44
-$(S)/pjdfstest/tests/open/03.t           (Wstat: 256 Tests: 4 Failed: 0)
-  Non-zero exit status: 1
+$(S)/pjdfstest/tests/open/02.t           (Wstat: 0 Tests: 4 Failed: 1)
+  Failed test:  4
 $(S)/pjdfstest/tests/open/06.t           (Wstat: 0 Tests: 144 Failed: 47)
   Failed tests:  65-111
-$(S)/pjdfstest/tests/open/17.t           (Wstat: 0 Tests: 3 Failed: 3)
-  Failed tests:  1-3
 $(S)/pjdfstest/tests/open/21.t           (Wstat: 0 Tests: 2 Failed: 1)
   Failed test:  2
 $(S)/pjdfstest/tests/open/24.t           (Wstat: 0 Tests: 5 Failed: 5)
   Failed tests:  1-5
-$(S)/pjdfstest/tests/rename/02.t         (Wstat: 256 Tests: 6 Failed: 0)
-  Non-zero exit status: 1
+$(S)/pjdfstest/tests/rename/01.t         (Wstat: 0 Tests: 8 Failed: 3)
+  Failed tests:  6-8
 $(S)/pjdfstest/tests/rename/09.t         (Wstat: 0 Tests: 441 Failed: 72)
   Failed tests:  140-142, 144-145, 150-151, 154, 158-160
                 162-163, 168-169, 172, 306-308, 310-311
@@ -53,26 +49,27 @@ $(S)/pjdfstest/tests/rename/17.t         (Wstat: 0 Tests: 8 Failed: 4)
   Failed tests:  3, 6-8
 $(S)/pjdfstest/tests/rmdir/01.t          (Wstat: 0 Tests: 14 Failed: 3)
   Failed tests:  12-14
-$(S)/pjdfstest/tests/rmdir/03.t          (Wstat: 256 Tests: 5 Failed: 0)
-  Non-zero exit status: 1
+$(S)/pjdfstest/tests/rmdir/02.t          (Wstat: 0 Tests: 4 Failed: 1)
+  Failed test:  4
 $(S)/pjdfstest/tests/rmdir/11.t          (Wstat: 0 Tests: 47 Failed: 6)
   Failed tests:  36-38, 43-45
 $(S)/pjdfstest/tests/rmdir/15.t          (Wstat: 0 Tests: 2 Failed: 1)
   Failed test:  2
-$(S)/pjdfstest/tests/symlink/03.t        (Wstat: 256 Tests: 6 Failed: 2)
+$(S)/pjdfstest/tests/symlink/02.t        (Wstat: 0 Tests: 7 Failed: 1)
+  Failed test:  5
+$(S)/pjdfstest/tests/symlink/03.t        (Wstat: 0 Tests: 6 Failed: 2)
   Failed tests:  1-2
-  Non-zero exit status: 1
 $(S)/pjdfstest/tests/symlink/12.t        (Wstat: 0 Tests: 6 Failed: 3)
   Failed tests:  2, 4-5
-$(S)/pjdfstest/tests/truncate/03.t       (Wstat: 256 Tests: 5 Failed: 0)
-  Non-zero exit status: 1
+$(S)/pjdfstest/tests/truncate/02.t       (Wstat: 0 Tests: 5 Failed: 1)
+  Failed test:  5
 $(S)/pjdfstest/tests/truncate/14.t       (Wstat: 0 Tests: 2 Failed: 1)
   Failed test:  2
 $(S)/pjdfstest/tests/unlink/00.t         (Wstat: 0 Tests: 112 Failed: 66)
   Failed tests:  10-12, 14-16, 18-20, 22-24, 31-50, 55-70
                 75, 78-81, 84-87, 90-93, 96-99, 105
-$(S)/pjdfstest/tests/unlink/03.t         (Wstat: 256 Tests: 4 Failed: 0)
-  Non-zero exit status: 1
+$(S)/pjdfstest/tests/unlink/02.t         (Wstat: 0 Tests: 4 Failed: 1)
+  Failed test:  4
 $(S)/pjdfstest/tests/unlink/11.t         (Wstat: 0 Tests: 94 Failed: 12)
   Failed tests:  39-41, 46-48, 83-85, 90-92
 $(S)/pjdfstest/tests/unlink/13.t         (Wstat: 0 Tests: 2 Failed: 1)
@@ -81,5 +78,5 @@ $(S)/pjdfstest/tests/utimensat/06.t      (Wstat: 0 Tests: 13 Failed: 1)
   Failed test:  4
 $(S)/pjdfstest/tests/utimensat/07.t      (Wstat: 0 Tests: 17 Failed: 6)
   Failed tests:  5-7, 9-11
-Files=232, Tests=3076, $(N) wallclock secs ( $(FP) usr  $(FP) sys + $(FP) cusr $(FP) csys = $(FP) CPU)
+Files=232, Tests=3074, $(N) wallclock secs ($(FP) usr  $(FP) sys + $(FP) cusr $(FP) csys = $(FP) CPU)
 Result: FAIL


### PR DESCRIPTION
It seems pjdfstest doesn't reliably report failed test number when
test stops with non-zero exit status.

Now that we fixed the underlying issue (I think it was missing support
for dup/dup2), we can see which of the sub-tests are failing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/351)
<!-- Reviewable:end -->
