### PR TITLE
Allow code coverage to drop by 0.2%.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,9 +2,11 @@ coverage:
   status:
     project:
       posix:
+        threshold: 0.2
         paths:
           - src/libpmemfile-posix/
       preload:
+        threshold: 0.2
         paths:
           - src/libpmemfile/
       antool:


### PR DESCRIPTION
Even if we could fix tests to always hit all code paths, we can't fix
gcov (which sometimes reports impossible coverage changes). The only
sane solution is to allow coverage to drop by some small number.
0.2% seems to be enough to cover most problems.

https://docs.codecov.io/docs/commit-status#section-threshold

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/352)
<!-- Reviewable:end -->
