### PR TITLE
Update the list of failing SQLite short tests.

### DIFF
--- a/utils/docker/sqlite/failing_short_tests
+++ b/utils/docker/sqlite/failing_short_tests
@@ -1,4 +1,3 @@
-attach.test
 attach4.test
 crash8.test
 dbstatus2.test
@@ -43,7 +42,6 @@ superlock.test
 symlink.test
 sync2.test
 syscall.test
-temptable.test
 tkt-2d1a5c67d.test
 tkt-313723c356.test
 tkt-5d863f876e.test


### PR DESCRIPTION
Fixed by #354.

There is a bug in run-build-sqlite.sh which does not fail the build when
the list of failed tests changes. It's going to be fixed in #324.
For now just update this list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/356)
<!-- Reviewable:end -->
