### PR TITLE
posix: change ftruncate errno for readonly file to EINVAL

### DIFF
--- a/src/libpmemfile-posix/truncate.c
+++ b/src/libpmemfile-posix/truncate.c
@@ -156,8 +156,13 @@ pmemfile_ftruncate(PMEMfilepool *pfp, PMEMfile *file, pmemfile_off_t length)
 		return -1;
 	}
 
-	if (!(flags & PFILE_WRITE)) {
+	if (flags & PFILE_PATH) {
 		errno = EBADF;
+		return -1;
+	}
+
+	if (!(flags & PFILE_WRITE)) {
+		errno = EINVAL;
 		return -1;
 	}
 

--- a/tests/posix/rw/rw.cpp
+++ b/tests/posix/rw/rw.cpp
@@ -635,6 +635,17 @@ TEST_F(rw, ftruncate)
 
 	pmemfile_close(pfp, f);
 	ASSERT_EQ(pmemfile_rmdir(pfp, "/dir"), 0);
+
+	errno = 0;
+	f = pmemfile_open(pfp, "/file1", PMEMFILE_O_CREAT | PMEMFILE_O_RDONLY,
+			  0);
+	ASSERT_NE(f, nullptr) << strerror(errno);
+
+	ASSERT_EQ(pmemfile_ftruncate(pfp, f, 4), -1);
+	EXPECT_EQ(errno, EINVAL);
+
+	pmemfile_close(pfp, f);
+	ASSERT_EQ(pmemfile_unlink(pfp, "/file1"), 0);
 }
 
 TEST_F(rw, truncate)

--- a/utils/docker/external_tests/ltp/failing_short_tests
+++ b/utils/docker/external_tests/ltp/failing_short_tests
@@ -54,8 +54,6 @@ flock04
 flock05
 flock06
 fork10
-ftruncate03
-ftruncate03_64
 getcwd03
 getdents02
 getdents02 -l


### PR DESCRIPTION
Fixing error occuring in LTP test ftruncate03.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/361)
<!-- Reviewable:end -->
