### PR TITLE
antool: correct test for realpath()

### DIFF
--- a/src/tools/antool/listsyscalls.py
+++ b/src/tools/antool/listsyscalls.py
@@ -96,7 +96,7 @@ def realpath(path):
         if dir in ("", "."):
             continue
 
-        if dir == ".." and dirs.index(dir) > 0:
+        if dir == "..":
             len_newdirs = len(newdirs)
             if len_newdirs > 0:
                 del newdirs[len_newdirs - 1]

--- a/tests/antool/dir_pmem.txt
+++ b/tests/antool/dir_pmem.txt
@@ -1,1 +1,1 @@
-/tmp/REMOVE/../antool LAz/REMOVE/../pmem QAl
+/tmp/antool LAz/pmem QAl

--- a/tests/antool/test-fi.sh
+++ b/tests/antool/test-fi.sh
@@ -321,7 +321,8 @@ case $NUM in
 	replace_n_bytes $BIN_LOG 82384 4 '\x00\x00\x00\x00'
 	# change fallocate's argument #4
 	replace_n_bytes $BIN_LOG 82392 4 '\x00\x00\x00\x00'
-	ANTOOL_OPTS="-m16 -s -d -p /etc"
+	# add test for resolving pmem paths
+	ANTOOL_OPTS="-m16 -s -d -p /../../REMOVE_THIS/AND_THAT_TOO/../../etc"
 	;;
 35)	# change syscall in packet #14 from close to SyS_symlinkat
 	replace_n_bytes $BIN_LOG 82352 2 '\x0A\x01'


### PR DESCRIPTION
Move testing pmem paths to fault injection tests,
because the 'dir_pmem.txt' file can be regenerated
and modified.

Remove also incorrect check from realpath().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/370)
<!-- Reviewable:end -->
