### PR TITLE
fuse: add -fno-strict-aliasing flag

### DIFF
--- a/src/pmemfile-fuse/CMakeLists.txt
+++ b/src/pmemfile-fuse/CMakeLists.txt
@@ -43,6 +43,7 @@ endif()
 
 include_directories(${FUSE_INCLUDE_DIRS})
 link_directories(${FUSE_LIBRARY_DIRS})
+add_c_flag(-fno-strict-aliasing)
 
 add_executable(pmemfile-fuse main.c)
 target_link_libraries(pmemfile-fuse PRIVATE ${FUSE_LIBRARIES})


### PR DESCRIPTION
Because of:
```
src/pmemfile-fuse/main.c: In function ‘pmemfile_fuse_readdir’:
src/pmemfile-fuse/main.c:146:4: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
    unsigned long nextoff = *(unsigned long *)&dirp[i];
    ^
src/pmemfile-fuse/main.c:149:4: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
    unsigned short reclen = *(unsigned short *)&dirp[i];
    ^
```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/371)
<!-- Reviewable:end -->
