### PR TITLE
Update NVML back to master

### DIFF
--- a/utils/docker/external_tests/ltp/short_tests
+++ b/utils/docker/external_tests/ltp/short_tests
@@ -32,7 +32,7 @@ chroot02
 chroot03
 chroot04
 clone01
-clone02
+#clone02
 clone03
 clone04
 clone05

--- a/utils/docker/images/install-nvml.sh
+++ b/utils/docker/images/install-nvml.sh
@@ -36,8 +36,7 @@
 
 git clone https://github.com/pmem/nvml.git
 cd nvml
-#git checkout 3fdd3f91bf55d93779d05a680726f08c810511dd
-git checkout 1.3
+git checkout 3fdd3f91bf55d93779d05a680726f08c810511dd
 BUILD_PACKAGE_CHECK=n make $1 EXTRA_CFLAGS="-DUSE_VALGRIND"
 if [ "$1" = "dpkg" ]; then
 	sudo dpkg -i dpkg/libpmem_*.deb dpkg/libpmem-dev_*.deb


### PR DESCRIPTION
With #372 merged and disabling of clone02 test we can use nvml from master again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/374)
<!-- Reviewable:end -->
