### PR TITLE
posix: translate ENOMEM to ENOSPC when it's allowed

### DIFF
--- a/src/libpmemfile-posix/fallocate.c
+++ b/src/libpmemfile-posix/fallocate.c
@@ -96,6 +96,8 @@ vinode_fallocate(PMEMfilepool *pfp, struct pmemfile_vinode *vinode, int mode,
 			inode->allocated_space = allocated_space;
 		}
 	} TX_ONABORT {
+		if (errno == ENOMEM)
+			errno = ENOSPC;
 		error = errno;
 		vinode_restore_on_abort(vinode);
 	} TX_END

--- a/src/libpmemfile-posix/file.c
+++ b/src/libpmemfile-posix/file.c
@@ -411,6 +411,8 @@ _pmemfile_openat(PMEMfilepool *pfp, struct pmemfile_vinode *dir,
 					info.remaining, namelen, tinode,
 					PF_RO(pfp, tinode)->ctime);
 		} TX_ONABORT {
+			if (errno == ENOMEM)
+				errno = ENOSPC;
 			error = errno;
 		} TX_END
 

--- a/src/libpmemfile-posix/link.c
+++ b/src/libpmemfile-posix/link.c
@@ -107,6 +107,8 @@ _pmemfile_linkat(PMEMfilepool *pfp,
 		inode_add_dirent(pfp, dst.parent->tinode, dst.remaining,
 				dst_namelen, src_vinode->tinode, t);
 	} TX_ONABORT {
+		if (errno == ENOMEM)
+			errno = ENOSPC;
 		error = errno;
 	} TX_END
 

--- a/src/libpmemfile-posix/mkdir.c
+++ b/src/libpmemfile-posix/mkdir.c
@@ -127,6 +127,8 @@ _pmemfile_mkdirat(PMEMfilepool *pfp, struct pmemfile_vinode *dir,
 		vinode_new_dir(pfp, parent, info.remaining, namelen, &cred,
 				mode);
 	} TX_ONABORT {
+		if (errno == ENOMEM)
+			errno = ENOSPC;
 		error = errno;
 	} TX_END
 

--- a/src/libpmemfile-posix/rename.c
+++ b/src/libpmemfile-posix/rename.c
@@ -159,6 +159,8 @@ vinode_exchange(PMEMfilepool *pfp,
 			}
 		}
 	} TX_ONABORT {
+		if (errno == ENOMEM)
+			errno = ENOSPC;
 		error = errno;
 	} TX_END
 

--- a/src/libpmemfile-posix/symlink.c
+++ b/src/libpmemfile-posix/symlink.c
@@ -98,6 +98,8 @@ _pmemfile_symlinkat(PMEMfilepool *pfp, const char *target,
 		inode_add_dirent(pfp, vparent->tinode, info.remaining, namelen,
 				tinode, inode->ctime);
 	} TX_ONABORT {
+		if (errno == ENOMEM)
+			errno = ENOSPC;
 		error = errno;
 	} TX_END
 


### PR DESCRIPTION
There are few cases when ENOSPC would make sense, but I don't see it
specified as valid errno in applicable man page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/383)
<!-- Reviewable:end -->
