### PR TITLE
tests: detect too long parameter

### DIFF
--- a/tests/preload/xattr/xattr.c
+++ b/tests/preload/xattr/xattr.c
@@ -80,7 +80,10 @@ main(int argc, char *argv[])
 	if (memcmp(lorem, value, sizeof(lorem)) != 0)
 		err(6, "unexpected attr1 value: %s", value);
 
-	sprintf(path, "%s/mount_point/../file", argv[1]);
+	const char *fmt = "%s/mount_point/../file";
+	if (strlen(argv[1]) + strlen(fmt) >= sizeof(path))
+		err(61, "too long path");
+	sprintf(path, fmt, argv[1]);
 
 	memset(value, 0, sizeof(value));
 	size = getxattr(path, "user.attr1", value, sizeof(value));


### PR DESCRIPTION
... which can lead to buffer overflow and stack corruption.

Found by Coverity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/386)
<!-- Reviewable:end -->
