### PR TITLE
antool: fix match file of 'antool-analyze' test

### DIFF
--- a/tests/antool/cut-126-15.log.match
+++ b/tests/antool/cut-126-15.log.match
@@ -130,15 +130,15 @@ fcntl                "/tmp/antool $(S)/nonp $(S)/tmp $(S)"
 fcntl                "/tmp/antool $(S)/pmem $(S)/tmp $(S)" [PMEM]
 fcntl                "/tmp/antool $(S)/nonp $(S)/tmp $(S)"
 fcntl                "/tmp/antool $(S)/pmem $(S)/tmp $(S)" [PMEM]
-mmap                 (-1)
-mmap                 (-1)
-mmap                 (-1)
-mmap                 (-1)
-mmap                 (-1)
-mmap                 (-1)
-mmap                 (-1)
-mmap                 (-1)
-mmap                 (-1)
-mmap                 (-1)
+$(OPT)mmap                 (-1)
+$(OPT)mmap                 (-1)
+$(OPT)mmap                 (-1)
+$(OPT)mmap                 (-1)
+$(OPT)mmap                 (-1)
+$(OPT)mmap                 (-1)
+$(OPT)mmap                 (-1)
+$(OPT)mmap                 (-1)
+$(OPT)mmap                 (-1)
+$(OPT)mmap                 (-1)
 close                "/tmp/antool $(S)/pmem $(S)/tmp $(S)" [PMEM]
 close                (0x0000000087654321)


### PR DESCRIPTION
Ten SyS_mmap calls come from ten pthread_create() calls in this file.
It happens that not all of them are detected, what causes sporadic
failures of this test. Make them optional, because detecting all of them
is not important.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/391)
<!-- Reviewable:end -->
