### PR TITLE
antool: fix handling empty paths

### DIFF
--- a/src/tools/antool/listsyscalls.py
+++ b/src/tools/antool/listsyscalls.py
@@ -587,9 +587,7 @@ class ListSyscalls(list):
             is_pmem = 0
         else:
             # handle relative paths
-            if len(path) == 0:
-                path = self.get_cwd(syscall)
-            elif path[0] != '/':
+            if len(path) > 0 and path[0] != '/':
                 path = self.get_cwd(syscall) + "/" + path
 
             is_pmem = self.is_path_pmem(self.realpath(path))
@@ -718,9 +716,6 @@ class ListSyscalls(list):
                 if len(path) != 0 and path[0] != '/':
                     self.all_strings_append(path, 0)  # add relative path as non-pmem
                     path = self.get_cwd(syscall) + "/" + path
-                # handle empty paths
-                elif len(path) == 0 and not syscall.read_error:
-                    path = self.get_cwd(syscall)
 
                 is_pmem = self.is_path_pmem(self.realpath(path))
                 syscall.is_pmem |= is_pmem
@@ -754,10 +749,6 @@ class ListSyscalls(list):
                         if len(path) != 0 and path[0] != '/':
                             self.all_strings_append(path, 0)  # add relative path as non-pmem
                             path = self.get_cwd(syscall) + "/" + path
-
-                        # handle empty paths
-                        elif len(path) == 0 and not syscall.read_error:
-                            path = self.get_cwd(syscall)
 
                         is_pmem = self.is_path_pmem(self.realpath(path))
                         syscall.is_pmem |= is_pmem

--- a/tests/antool/output-err-fi-23.log.match
+++ b/tests/antool/output-err-fi-23.log.match
@@ -7,7 +7,7 @@ DEBUG(main): print_progress = 0
 DEBUG(syscalltable): format of syscall table OK, reading 1000 records...
 DEBUG(syscalltable): read 1000 records of syscall table.
 DEBUG(parser): 0x000447D4D13A8361 0x0000254E0000254E ------------------ ------------------ execve "" 0x00007FFC9E8BC528 0x00007FFC9E8BC540
-DEBUG(analysis): execve               "$(*)/tests/antool/logs-test-parser.sh-14-1531-2017-07-27_09:05:31_242116266-9110"
+DEBUG(analysis): execve               ""
 DEBUG(parser): 0x000447D4D13F74C1 0x0000254E0000254E 0x0000000000000000 0x0000000000000000 execve
 DEBUG(parser): 0x000447D4D13FBA92 0x0000254E0000254E ------------------ ------------------ brk 0x0000000000000000
 DEBUG(parser): 0x000447D4D13FC18C 0x0000254E0000254E 0x0000000000000000 0x0000000001F0E000 brk

--- a/tests/antool/output-err-fi-35.log.match
+++ b/tests/antool/output-err-fi-35.log.match
@@ -27,6 +27,6 @@ DEBUG(parser): 0x000447D4D1406134 0x0000254E0000254E ------------------ --------
 DEBUG(analysis): mmap                 "/etc/ld.so.cache" [PMEM]
 DEBUG(parser): 0x000447D4D1406DE6 0x0000254E0000254E 0x0000000000000000 0x00007F6C96F09000 mmap
 DEBUG(parser): 0x000447D4D1407291 0x0000254E0000254E ------------------ ------------------ symlinkat "" 0x00000000FFFFFF9C ""
-DEBUG(analysis): symlinkat            "/mnt/$(S)/pmemfile/build/tests/antool/logs-test-parser.sh-14-1531-2017-07-27_09:05:31_242116266-9110" [PMEM] "/mnt/$(S)/pmemfile/build/tests/antool/logs-test-parser.sh-14-1531-2017-07-27_09:05:31_242116266-9110" "" [PMEM]
+DEBUG(analysis): symlinkat            "" "/mnt/$(S)/pmemfile/build/tests/antool/logs-test-parser.sh-14-1531-2017-07-27_09:05:31_242116266-9110" "" [PMEM]
 DEBUG(analysis): INFO: new symlink added to pmem paths: "/mnt/$(S)/pmemfile/build/tests/antool/logs-test-parser.sh-14-1531-2017-07-27_09:05:31_242116266-9110"
 DEBUG(parser): 0x000447D4D14075F7 0x0000254E0000254E 0x0000000000000000 0x0000000000000000 symlinkat


### PR DESCRIPTION
Empty paths should not be replaced with the CWD during analysis.