### PR TITLE
antool: add option for printing syscalls to analysis log

### DIFF
--- a/src/tools/antool/antool.py
+++ b/src/tools/antool/antool.py
@@ -56,9 +56,9 @@ DO_REINIT = 1
 ########################################################################################################################
 class AnalyzingTool(ListSyscalls):
     def __init__(self, convert_mode, pmem_paths, slink_file, fileout, max_packets, offline_mode,
-                 script_mode, debug_mode, print_log_mode, verbose_mode):
+                 script_mode, debug_mode, print_log_mode, verbose_mode, print_all):
 
-        ListSyscalls.__init__(self, pmem_paths, slink_file, script_mode, debug_mode, verbose_mode,
+        ListSyscalls.__init__(self, pmem_paths, slink_file, script_mode, debug_mode, verbose_mode, print_all,
                               init_pmem=(not offline_mode))
 
         self.convert_mode = convert_mode
@@ -104,10 +104,10 @@ class AnalyzingTool(ListSyscalls):
         self.log_main.debug("debug_mode     = {0:d}".format(self.debug_mode))
         self.log_main.debug("print_progress = {0:d}".format(self.print_progress))
 
-        self.list_ok = ListSyscalls(pmem_paths, slink_file, script_mode, debug_mode, verbose_mode,
+        self.list_ok = ListSyscalls(pmem_paths, slink_file, script_mode, debug_mode, verbose_mode, print_all,
                                     init_pmem=offline_mode)
-        self.list_no_exit = ListSyscalls(pmem_paths, slink_file, script_mode, debug_mode, verbose_mode)
-        self.list_others = ListSyscalls(pmem_paths, slink_file, script_mode, debug_mode, verbose_mode)
+        self.list_no_exit = ListSyscalls(pmem_paths, slink_file, script_mode, debug_mode, verbose_mode, print_all)
+        self.list_others = ListSyscalls(pmem_paths, slink_file, script_mode, debug_mode, verbose_mode, print_all)
 
     ####################################################################################################################
     def read_syscall_table(self, fh):
@@ -445,9 +445,13 @@ def main():
     parser.add_argument("-d", "--debug", action='store_true', required=False, help="debug mode")
     parser.add_argument("-f", "--offline", action='store_true', required=False, help="offline analysis mode")
 
+    parser.add_argument("-t", "--print-all-syscalls", action='store_true', required=False,
+                        help="print also syscalls without path or file descriptor among arguments to the analysis log")
+
     parser.add_argument("--slink-file", required=False, help="resolve symlinks saved in the given file")
 
     args = parser.parse_args()
+    print_all = args.print_all_syscalls
 
     if args.verbose:
         verbose = args.verbose
@@ -455,7 +459,7 @@ def main():
         verbose = 0
 
     at = AnalyzingTool(args.convert, args.pmem, args.slink_file, args.output, args.max_packets, args.offline,
-                       args.script, args.debug, args.log, verbose)
+                       args.script, args.debug, args.log, verbose, print_all)
 
     at.read_and_parse_data(args.binlog)
 

--- a/src/tools/antool/listsyscalls.py
+++ b/src/tools/antool/listsyscalls.py
@@ -84,7 +84,7 @@ MAX_DEC_FD = 0x10000000
 # ListSyscalls
 ########################################################################################################################
 class ListSyscalls(list):
-    def __init__(self, pmem_paths, slink_file, script_mode, debug_mode, verbose_mode, init_pmem=0):
+    def __init__(self, pmem_paths, slink_file, script_mode, debug_mode, verbose_mode, print_all, init_pmem=0):
 
         list.__init__(self)
 
@@ -95,6 +95,7 @@ class ListSyscalls(list):
         self.script_mode = script_mode
         self.debug_mode = debug_mode
         self.verbose_mode = verbose_mode
+        self.print_all = print_all
 
         self.print_progress = not (self.debug_mode or self.script_mode)
 
@@ -800,6 +801,10 @@ class ListSyscalls(list):
                             msg += " (0x{0:016X})".format(fd)
 
             self.log_anls.debug(msg)
+
+        else:
+            if self.print_all:
+                self.log_anls.debug("{0:s}".format(syscall.name))
 
         self.post_match_action(syscall)
 

--- a/tests/antool/output-err-fi-5.log.match
+++ b/tests/antool/output-err-fi-5.log.match
@@ -18,6 +18,7 @@ DEBUG(parser): 0x000447D4D1403BB4 0x0000254E0000254E ------------------ --------
 DEBUG(parser): 0x000447D4D1404F48 0x0000254E0000254E 0x0000000000000000 0x0000000000000005 open
 DEBUG(analysis): PID[0] = 0x000000000000254E
 DEBUG(analysis): execve               "$(*)/tests/antool/test_syscalls"
+DEBUG(analysis): brk
 DEBUG(analysis): mmap                 (-1)
 DEBUG(analysis): access               "/etc/ld.so.preload"
 DEBUG(analysis): open                 "/etc/ld.so.cache"

--- a/tests/antool/test-fi.sh
+++ b/tests/antool/test-fi.sh
@@ -160,7 +160,7 @@ case $NUM in
 	ANTOOL_OPTS="-m 10 -l -s -f"
 	;;
 5)
-	ANTOOL_OPTS="-m 10 -l -s -f -d"
+	ANTOOL_OPTS="-m 10 -l -s -f -d --print-all-syscalls"
 	;;
 6)
 	# non-existing input file


### PR DESCRIPTION
Add the "--print-syscalls-without-path-or-fd" option
which makes it possible to print to the analysis log
also syscalls without a path or a file descriptor among arguments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/401)
<!-- Reviewable:end -->
