### PR TITLE
posix: limit symlink length to 4k

### DIFF
--- a/src/libpmemfile-posix/symlink.c
+++ b/src/libpmemfile-posix/symlink.c
@@ -93,6 +93,11 @@ _pmemfile_symlinkat(PMEMfilepool *pfp, const char *target,
 	const struct pmem_block_info *block_info =
 			data_block_info(len + 1, MAX_BLOCK_SIZE);
 
+	if (len + 1 > PMEMFILE_PATH_MAX) {
+		error = ENAMETOOLONG;
+		goto end;
+	}
+
 	if (len + 1 > block_info->size) {
 		error = ENAMETOOLONG;
 		goto end;


### PR DESCRIPTION
Fixes regression from 4fb52410a9141197f8d5b1530f8ad1a3d9f3104c on
one of tests in pjdfstest.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/412)
<!-- Reviewable:end -->
