### PR TITLE
external_tests: rerun new failing tests with logging enabled

### DIFF
--- a/utils/docker/external_tests/tester.py
+++ b/utils/docker/external_tests/tester.py
@@ -105,6 +105,13 @@ class Tester:
             for fail in new_fails:
                 print(fail)
 
+            print('')
+            self.suite.verbose = True
+            for fail in new_fails:
+                print('Rerunning test {0}:'.format(fail))
+                self.suite.run(fail, on_pf=True)
+                print('End out output for {0}\n'.format(fail));
+
         removed_fails = sorted(set(past_fails) -
                                (set(self.failed_pf_only) | set(self.failed_both)))
         if removed_fails:


### PR DESCRIPTION
Example:

```
New test failures introduced in this execution:
rename08
rmdir05

Rerunning test rename08:
rename08    1  TBROK  :  /home/user/ltp/lib/tst_sig.c:233: unexpected signal SIGSEGV(11) received (pid = 3135).
rename08    2  TBROK  :  /home/user/ltp/lib/tst_sig.c:233: Remaining cases broken
rename08    0  TWARN  :  /home/user/ltp/lib/tst_tmpdir.c:337: tst_rmdir: rmobj(/home/user/testdir/mountpoint/renzDHAom) failed: unlink(/home/user/testdir/mountpoint/renzDHAom) failed; errno=2: ENOENT

End out output for rename08

Rerunning test rmdir05:
rmdir05     1  TPASS  :  rmdir(".") failed to remove the current working directory. Returned 22 : Invalid argument
rmdir05     2  TCONF  :  /home/user/ltp/testcases/kernel/syscalls/rmdir/rmdir05.c:112: rmdir on "dir/." supported on Linux
rmdir05     3  TCONF  :  /home/user/ltp/testcases/kernel/syscalls/rmdir/rmdir05.c:115: linked directories test not implemented on Linux
rmdir05     4  TBROK  :  /home/user/ltp/lib/tst_sig.c:233: unexpected signal SIGSEGV(11) received (pid = 3136).
rmdir05     5  TBROK  :  /home/user/ltp/lib/tst_sig.c:233: Remaining cases broken
rmdir05     0  TWARN  :  /home/user/ltp/lib/tst_tmpdir.c:337: tst_rmdir: rmobj(/home/user/testdir/mountpoint/rmdWyvgJE) failed: unlink(/home/user/testdir/mountpoint/rmdWyvgJE) failed; errno=2: ENOENT

End out output for rmdir05
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/416)
<!-- Reviewable:end -->
