### PR TITLE
posix: fix harmless race between exchange and unref

### DIFF
--- a/src/libpmemfile-posix/inode.c
+++ b/src/libpmemfile-posix/inode.c
@@ -198,7 +198,7 @@ vinode_free_pmem(PMEMfilepool *pfp, struct pmemfile_vinode *vinode)
 			LOG(LINF, "Freeing inode %lu failed!",
 				vinode->tinode.oid.off);
 		else
-			FATAL("!vinode_unref");
+			FATAL("!vinode_free_pmem");
 	} TX_END
 }
 
@@ -214,63 +214,54 @@ vinode_unref(PMEMfilepool *pfp, struct pmemfile_vinode *vinode)
 
 	os_rwlock_wrlock(&pfp->inode_map_rwlock);
 
-	while (vinode) {
-		struct pmemfile_vinode *to_unregister = NULL;
-		struct pmemfile_vinode *parent = NULL;
+	while (vinode && __sync_sub_and_fetch(&vinode->ref, 1) == 0) {
+		struct pmemfile_inode *inode = vinode->inode;
 
-		if (__sync_sub_and_fetch(&vinode->ref, 1) == 0) {
-			uint64_t nlink = inode_get_nlink(vinode->inode);
-			if (vinode->inode->suspended_references == 0 &&
-					nlink == 0)
-				vinode_free_pmem(pfp, vinode);
-			else if (vinode->atime_dirty) {
-				struct pmemfile_inode *inode = vinode->inode;
-				bool atime_slot = inode_next_atime_slot(inode);
-				inode->atime[atime_slot] = vinode->atime;
-				pmemfile_persist(pfp,
-						&inode->atime[atime_slot]);
+		uint64_t nlink = inode_get_nlink(inode);
+		if (inode->suspended_references == 0 && nlink == 0) {
+			vinode_free_pmem(pfp, vinode);
+			inode = vinode->inode = NULL;
+		} else if (vinode->atime_dirty) {
+			inode_slot atime_slot = inode_next_atime_slot(inode);
+			inode->atime[atime_slot] = vinode->atime;
+			pmemfile_persist(pfp, &inode->atime[atime_slot]);
 
-				inode->slots.bits.atime = atime_slot;
-				pmemfile_persist(pfp, &inode->slots);
-			}
-
-			to_unregister = vinode;
-			/*
-			 * We don't need to take the vinode lock to read parent
-			 * because at this point (when ref count drops to 0)
-			 * nobody should have access to this vinode.
-			 */
-			parent = vinode->parent;
+			inode->slots.bits.atime = atime_slot;
+			pmemfile_persist(pfp, &inode->slots);
 		}
 
 		/*
+		 * We don't need to take the vinode lock to read parent because
+		 * at this point (when ref count drops to 0) nobody should have
+		 * access to this vinode.
+		 *
 		 * Can't use vinode_is_root here, as that function dereferences
 		 * vinode->inode, which might point to already deallocated
 		 * memory -- see vinode_free_pmem call above.
 		 */
-		if (vinode->parent != vinode)
-			vinode = parent;
+		struct pmemfile_vinode *next;
+		if (vinode->parent && vinode->parent != vinode)
+			next = vinode->parent;
 		else
-			vinode = NULL;
+			next = NULL;
 
-		if (to_unregister) {
-			struct hash_map *map = pfp->inode_map;
+		struct hash_map *map = pfp->inode_map;
 
-			if (hash_map_remove(map,
-					to_unregister->tinode.oid.off,
-					to_unregister))
-				FATAL("vinode not found");
+		if (hash_map_remove(map, vinode->tinode.oid.off,
+				vinode))
+			FATAL("vinode not found");
 
-			if (to_unregister->blocks)
-				ctree_delete(to_unregister->blocks);
+		if (vinode->blocks)
+			ctree_delete(vinode->blocks);
 
 #ifdef DEBUG
-			/* "path" field is defined only in DEBUG builds */
-			pf_free(to_unregister->path);
+		/* "path" field is defined only in DEBUG builds */
+		pf_free(vinode->path);
 #endif
-			os_rwlock_destroy(&to_unregister->rwlock);
-			pf_free(to_unregister);
-		}
+		os_rwlock_destroy(&vinode->rwlock);
+		pf_free(vinode);
+
+		vinode = next;
 	}
 
 	os_rwlock_unlock(&pfp->inode_map_rwlock);


### PR DESCRIPTION
vinode->parent was compared to vinode (as a "is_root" check) without
holding vinode lock. However exchange won't ever set vinode->parent
to parent, so this race is harmless.
Fixing this race actually simplifies vinode_unref code.

Introduced by 3e3782e41f4f13836a033328130ff1a3b3ac8701.

```
==3433== Conflicting store by thread 13 at 0x06a3b3a0 size 8
==3433==    at 0x4E5A17C: vinode_exchange (rename.c:152)
==3433==    by 0x4E5AE1D: _pmemfile_renameat2 (rename.c:449)
==3433==    by 0x4E5B2E9: pmemfile_renameat2 (rename.c:559)
==3433==    by 0x4789FC: test_exchange(char const*, char const*) (mt.cpp:204)
==3433==    by 0x478A5E: test_exchange_loop(char const*, char const*) (mt.cpp:213)
==3433==    by 0x478B00: rename_worker6() (mt.cpp:261)
==3433==    by 0x485F0A: void std::_Bind_simple<void (*())()>::_M_invoke<>(std::_Index_tuple<>) (functional:1531)
==3433==    by 0x485C3D: std::_Bind_simple<void (*())()>::operator()() (functional:1520)
==3433==    by 0x48591F: std::thread::_Impl<std::_Bind_simple<void (*())()> >::_M_run() (thread:115)
==3433==    by 0x5762C7F: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21)
==3433==    by 0x4C33CAB: vgDrd_thread_wrapper (drd_pthread_intercepts.c:367)
==3433==    by 0x54946B9: start_thread (pthread_create.c:333)
==3433== Address 0x6a3b3a0 is at offset 112 from 0x6a3b330. Allocation context:
==3433==    at 0x4C32D27: calloc (vg_replace_malloc.c:623)
==3433==    by 0x4E614EA: _pf_calloc (alloc.c:70)
==3433==    by 0x4E50E9B: inode_ref (inode.c:118)
==3433==    by 0x4E4B0C3: vinode_lookup_vinode_by_name_locked (dir.c:312)
==3433==    by 0x4E4C0C7: lock_parents_and_children (dir.c:726)
==3433==    by 0x4E5AB45: _pmemfile_renameat2 (rename.c:363)
==3433==    by 0x4E5B2E9: pmemfile_renameat2 (rename.c:559)
==3433==    by 0x4789FC: test_exchange(char const*, char const*) (mt.cpp:204)
==3433==    by 0x478A5E: test_exchange_loop(char const*, char const*) (mt.cpp:213)
==3433==    by 0x478B00: rename_worker6() (mt.cpp:261)
==3433==    by 0x485F0A: void std::_Bind_simple<void (*())()>::_M_invoke<>(std::_Index_tuple<>) (functional:1531)
==3433==    by 0x485C3D: std::_Bind_simple<void (*())()>::operator()() (functional:1520)
==3433== Other segment start (thread 7)
==3433==    at 0x4C37E74: pthread_rwlock_trywrlock_intercept (drd_pthread_intercepts.c:1242)
==3433==    by 0x4C37E74: pthread_rwlock_trywrlock$* (drd_pthread_intercepts.c:1247)
==3433==    by 0x4E5553D: os_rwlock_wrlock (os_thread_pthread.c:109)
==3433==    by 0x4E512EA: vinode_unref (inode.c:215)
==3433==    by 0x4E5AF6D: _pmemfile_renameat2 (rename.c:475)
==3433==    by 0x4E5B2E9: pmemfile_renameat2 (rename.c:559)
==3433==    by 0x4789FC: test_exchange(char const*, char const*) (mt.cpp:204)
==3433==    by 0x478A5E: test_exchange_loop(char const*, char const*) (mt.cpp:213)
==3433==    by 0x478B00: rename_worker6() (mt.cpp:261)
==3433==    by 0x485F0A: void std::_Bind_simple<void (*())()>::_M_invoke<>(std::_Index_tuple<>) (functional:1531)
==3433==    by 0x485C3D: std::_Bind_simple<void (*())()>::operator()() (functional:1520)
==3433==    by 0x48591F: std::thread::_Impl<std::_Bind_simple<void (*())()> >::_M_run() (thread:115)
==3433==    by 0x5762C7F: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21)
==3433== Other segment end (thread 7)
==3433==    at 0x4C37F75: pthread_rwlock_unlock_intercept (drd_pthread_intercepts.c:1257)
==3433==    by 0x4C37F75: pthread_rwlock_unlock$* (drd_pthread_intercepts.c:1265)
==3433==    by 0x4E55592: os_rwlock_unlock (os_thread_pthread.c:119)
==3433==    by 0x4E51538: vinode_unref (inode.c:276)
==3433==    by 0x4E4BDBE: path_info_cleanup (dir.c:626)
==3433==    by 0x4E5AFA8: _pmemfile_renameat2 (rename.c:481)
==3433==    by 0x4E5B2E9: pmemfile_renameat2 (rename.c:559)
==3433==    by 0x4789FC: test_exchange(char const*, char const*) (mt.cpp:204)
==3433==    by 0x478A5E: test_exchange_loop(char const*, char const*) (mt.cpp:213)
==3433==    by 0x478B00: rename_worker6() (mt.cpp:261)
==3433==    by 0x485F0A: void std::_Bind_simple<void (*())()>::_M_invoke<>(std::_Index_tuple<>) (functional:1531)
==3433==    by 0x485C3D: std::_Bind_simple<void (*())()>::operator()() (functional:1520)
==3433==    by 0x48591F: std::thread::_Impl<std::_Bind_simple<void (*())()> >::_M_run() (thread:115)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/422)
<!-- Reviewable:end -->
