### PR TITLE
posix: fix possible use after free

### DIFF
--- a/src/libpmemfile-posix/file.c
+++ b/src/libpmemfile-posix/file.c
@@ -262,6 +262,7 @@ _pmemfile_openat(PMEMfilepool *pfp, struct pmemfile_vinode *dir,
 			/* XXX handle infinite symlink loop */
 			resolve_symlink(pfp, &cred, vinode, &info);
 			vinode_unref(pfp, vparent);
+			vinode = NULL;
 			path_info_changed = true;
 		}
 	} while (path_info_changed);


### PR DESCRIPTION
Reported by Coverity.
Fallout from f60769a0891a38dd1decdbd28abdd79ec010b9ac.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/430)
<!-- Reviewable:end -->
