### PR TITLE
common: fix Coverity builds

### DIFF
--- a/utils/docker/0001-travis-fix-travisci_build_coverity_scan.sh.patch
+++ b/utils/docker/0001-travis-fix-travisci_build_coverity_scan.sh.patch
@@ -1,0 +1,27 @@
+From b5179dc4822eaab192361da05aa95d98f523960f Mon Sep 17 00:00:00 2001
+From: Lukasz Dorau <lukasz.dorau@intel.com>
+Date: Mon, 7 May 2018 12:05:40 +0200
+Subject: [PATCH] travis: fix travisci_build_coverity_scan.sh
+
+---
+ travisci_build_coverity_scan.sh | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/travisci_build_coverity_scan.sh b/travisci_build_coverity_scan.sh
+index ad9d4afcf..562b08bcc 100644
+--- a/travisci_build_coverity_scan.sh
++++ b/travisci_build_coverity_scan.sh
+@@ -92,8 +92,8 @@ response=$(curl \
+   --form description="Travis CI build" \
+   $UPLOAD_URL)
+ status_code=$(echo "$response" | sed -n '$p')
+-if [ "$status_code" != "201" ]; then
++if [ "$status_code" != "200" ]; then
+   TEXT=$(echo "$response" | sed '$d')
+-  echo -e "\033[33;1mCoverity Scan upload failed: $TEXT.\033[0m"
++  echo -e "\033[33;1mCoverity Scan upload failed: $response.\033[0m"
+   exit 1
+ fi
+-- 
+2.13.6
+

--- a/utils/docker/run-coverity.sh
+++ b/utils/docker/run-coverity.sh
@@ -48,4 +48,20 @@ export COVERITY_SCAN_PROJECT_NAME="pmemfile"
 export COVERITY_SCAN_BUILD_COMMAND="make"
 
 # Run the Coverity scan
-curl -s https://scan.coverity.com/scripts/travisci_build_coverity_scan.sh | bash
+
+# XXX: Patch the Coverity script.
+# Recently, this script regularly exits with an error, even though
+# the build is successfully submitted.  Probably because the status code
+# is missing in response, or it's not 201.
+# Changes:
+# 1) change the expected status code to 200 and
+# 2) print the full response string.
+#
+# This change should be reverted when the Coverity script is fixed.
+#
+# The previous version was:
+# curl -s https://scan.coverity.com/scripts/travisci_build_coverity_scan.sh | bash
+
+wget https://scan.coverity.com/scripts/travisci_build_coverity_scan.sh
+patch < utils/docker/0001-travis-fix-travisci_build_coverity_scan.sh.patch
+bash ./travisci_build_coverity_scan.sh


### PR DESCRIPTION
Patch the Coverity script.
Recently, this script regularly exits with an error, even though
the build is successfully submitted.  Probably because the status code
is missing in response, or it's not 201.

Changes:
1) change the expected status code to 200 and
2) print the full response string.

This change should be reverted when the Coverity script is fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemfile/442)
<!-- Reviewable:end -->
